### PR TITLE
Refactor ECS models for deterministic ids

### DIFF
--- a/specs/001-title-simulation-spec/tasks.md
+++ b/specs/001-title-simulation-spec/tasks.md
@@ -131,9 +131,9 @@
       direction, ticks remaining, tick interval, damage per tick).
 - [x] T012 [P] Implement `src/utils/runtimeEventLog.ts` providing `DeathAuditEntry` types and a
       bounded ring buffer API (append/read/size/capacity) per observability contract.
-- [ ] T013 Refactor `src/ecs/miniplexStore.ts` to consume the new component modules, ensure
+- [x] T013 Refactor `src/ecs/miniplexStore.ts` to consume the new component modules, ensure
       deterministic id assignment, and expose helpers for `invulnerableUntil` tracking.
-- [ ] T014 Align `src/ecs/weapons.ts` with deterministic team/owner id types and remove implicit
+- [x] T014 Align `src/ecs/weapons.ts` with deterministic team/owner id types and remove implicit
       enums in preparation for StepContext-provided flags.
 - [x] T015 Extend `src/utils/seededRng.ts` with deterministic sequence helpers (idFactory, shuffle)
       consumed by StepContext.

--- a/src/ecs/miniplexStore.ts
+++ b/src/ecs/miniplexStore.ts
@@ -1,48 +1,30 @@
 import { createEntityLookup } from "./entityLookup";
+import {
+  createRobotComponent,
+  type RobotComponent,
+  type RobotInit,
+} from "./components/robot";
+import type { BeamComponent } from "./components/beam";
+import type { ProjectileComponent } from "./components/projectile";
 import type { FxComponent } from "./fx";
+import { ensureGameplayId, normalizeTeam } from "./id";
+import type { Team } from "./id";
 import {
   clearPauseVelocity,
   getPauseVelocity,
   setPauseVelocity,
 } from "./pauseVelocity";
 import { createRenderKeyGenerator } from "./renderKey";
-import type {
-  BeamComponent,
-  ProjectileComponent,
-  WeaponComponent,
-  WeaponStateComponent,
-} from "./weapons";
+import type { WeaponComponent, WeaponStateComponent } from "./weapons";
 import { createWorldController } from "./worldFactory";
 
-export type Vec3 = [number, number, number];
+export type { Team } from "./id";
 
-export type Team = "red" | "blue";
+export type Vec3 = [number, number, number];
 
 export interface Transform {
   position: Vec3;
   rotation: Vec3; // Euler in radians
-}
-
-export interface Health {
-  hp: number;
-  maxHp: number;
-  alive: boolean;
-}
-
-export interface Weapon {
-  range: number;
-  power: number;
-  cooldown: number; // seconds
-  cooldownLeft: number; // seconds
-}
-
-export interface RobotStats {
-  speed: number; // m/s
-  turnSpeed: number; // rad/s (not used yet)
-}
-
-export interface Target {
-  targetId?: number; // entity id of current target
 }
 
 export interface RigidBodyRef {
@@ -57,32 +39,29 @@ export const ROBOT_BASE_STATS = {
   hp: 100,
   maxHp: 100,
   alive: true,
-  range: 8,
-  power: 10,
-  cooldown: 1.0,
-  cooldownLeft: 0,
   speed: 3,
   turnSpeed: 4,
-} as const satisfies Partial<Entity>;
+} as const;
 
-export type Entity = Partial<
-  Transform &
-    Health &
-    Weapon &
-    RobotStats &
-    Target & {
-      id: string | number;
-      team: Team;
-    } & RigidBodyRef &
-    RenderRef & {
-      pauseVel?: { lin?: Vec3; ang?: Vec3 };
-      beam?: BeamComponent;
-      projectile?: ProjectileComponent;
-      weapon?: WeaponComponent;
-      weaponState?: WeaponStateComponent;
-      fx?: FxComponent;
-    }
->;
+export interface Entity extends Partial<Transform>, RigidBodyRef, RenderRef {
+  id?: number;
+  gameplayId?: string;
+  team?: Team;
+  hp?: number;
+  maxHp?: number;
+  alive?: boolean;
+  speed?: number;
+  turnSpeed?: number;
+  targetId?: number | string;
+  pauseVel?: { lin?: Vec3; ang?: Vec3 };
+  beam?: BeamComponent;
+  projectile?: ProjectileComponent;
+  weapon?: WeaponComponent;
+  weaponState?: WeaponStateComponent;
+  fx?: FxComponent;
+  robot?: RobotComponent;
+  invulnerableUntil?: number;
+}
 
 const entityLookup = createEntityLookup<Entity>();
 const worldController = createWorldController<Entity>({
@@ -100,6 +79,10 @@ export const notifyEntityChanged = (entity: Entity | undefined) =>
 
 export const getEntityById = (id: number) => entityLookup.getById(id);
 
+export function getGameplayId(entity: Entity): string | undefined {
+  return entity.gameplayId ?? entity.robot?.id;
+}
+
 export function getRobots() {
   return Array.from(world.entities).filter((e) => e.team && e.rigid);
 }
@@ -116,15 +99,85 @@ export function clearPauseVel(entity: Entity) {
   clearPauseVelocity(entity);
 }
 
-export function createRobotEntity(init: Partial<Entity>): Entity {
+function cloneVec3(vec: Vec3 | undefined): Vec3 {
+  if (!vec) {
+    return [0, 0, 0];
+  }
+  return [vec[0], vec[1], vec[2]];
+}
+
+export function createRobotEntity(init: Partial<Entity> = {}): Entity {
+  const position = cloneVec3(init.position);
+  const rotation = cloneVec3(init.rotation);
+
+  const team = init.team ? normalizeTeam(init.team) : ("red" as Team);
+
+  const baseHp = typeof init.hp === "number" ? init.hp : ROBOT_BASE_STATS.hp;
+  const baseMaxHp =
+    typeof init.maxHp === "number" ? init.maxHp : ROBOT_BASE_STATS.maxHp;
+  const baseAlive = typeof init.alive === "boolean" ? init.alive : baseHp > 0;
+
   const entity: Entity = {
-    position: [0, 0, 0],
-    rotation: [0, 0, 0],
-    ...ROBOT_BASE_STATS,
-    ...init,
+    position,
+    rotation,
+    hp: baseHp,
+    maxHp: baseMaxHp,
+    alive: baseAlive,
+    speed: init.speed ?? ROBOT_BASE_STATS.speed,
+    turnSpeed: init.turnSpeed ?? ROBOT_BASE_STATS.turnSpeed,
+    targetId: init.targetId,
+    rigid: init.rigid,
+    mesh: init.mesh,
+    pauseVel: init.pauseVel,
+    beam: init.beam,
+    projectile: init.projectile,
+    weapon: init.weapon ? { ...init.weapon } : undefined,
+    weaponState: init.weaponState ? { ...init.weaponState } : undefined,
+    fx: init.fx ? { ...init.fx } : undefined,
+    invulnerableUntil:
+      init.invulnerableUntil ?? init.robot?.invulnerableUntil ?? 0,
+    gameplayId: init.gameplayId,
+    team,
   };
 
-  entityLookup.ensureEntityId(entity);
+  const assignedId = entityLookup.ensureEntityId(entity);
+  const numericId = assignedId ?? (entity.id as number);
+
+  const gameplayId = ensureGameplayId(
+    entity.gameplayId ?? init.robot?.id ?? numericId,
+  );
+  entity.gameplayId = gameplayId;
+
+  const robotInit: RobotInit = {
+    id: gameplayId,
+    team,
+    health: {
+      current: entity.hp ?? baseHp,
+      max: entity.maxHp ?? baseMaxHp,
+      alive: entity.alive ?? baseAlive,
+    },
+    weapon: init.robot?.weapon,
+    weaponState: init.robot?.weaponState ?? entity.weaponState,
+    invulnerableUntil: entity.invulnerableUntil,
+  };
+
+  entity.robot = createRobotComponent(robotInit);
+  entity.invulnerableUntil = entity.robot.invulnerableUntil;
+  entity.hp = entity.robot.health.current;
+  entity.maxHp = entity.robot.health.max;
+  entity.alive = entity.robot.health.alive;
+  entity.team = entity.robot.team as Team;
+
+  if (entity.weapon) {
+    const ownerGameplayId = entity.gameplayId ?? String(numericId);
+    if (!entity.weapon.ownerId || entity.weapon.ownerId === "-1") {
+      entity.weapon.ownerId = ownerGameplayId;
+    } else {
+      entity.weapon.ownerId = ensureGameplayId(entity.weapon.ownerId);
+    }
+    entity.weapon.team = entity.robot.team as Team;
+  }
+
   const added = worldController.add(entity);
   entityLookup.track(added);
   return added;
@@ -141,4 +194,19 @@ export function resetWorld() {
 
 export function getRenderKey(entity: Entity, fallbackIndex?: number) {
   return renderKeyGenerator(entity, fallbackIndex);
+}
+
+export function getInvulnerableUntil(entity: Entity): number {
+  return entity.robot?.invulnerableUntil ?? entity.invulnerableUntil ?? 0;
+}
+
+export function setInvulnerableUntil(entity: Entity, timestamp: number) {
+  entity.invulnerableUntil = timestamp;
+  if (entity.robot) {
+    entity.robot.invulnerableUntil = timestamp;
+  }
+}
+
+export function clearInvulnerable(entity: Entity) {
+  setInvulnerableUntil(entity, 0);
 }

--- a/src/ecs/weapons.ts
+++ b/src/ecs/weapons.ts
@@ -1,26 +1,24 @@
-export type WeaponType = "gun" | "laser" | "rocket";
+import type { Team } from "./id";
+import type {
+  WeaponAmmo,
+  WeaponBeamParams,
+  WeaponFlags,
+  WeaponPayload,
+  WeaponType,
+} from "./weaponPayload";
 
-export interface WeaponComponent {
-  id: string;
-  type: WeaponType;
-  ownerId: number;
-  team: "red" | "blue";
-  range: number;
-  cooldown: number; // seconds
+export type { WeaponType } from "./weaponPayload";
+
+export interface WeaponComponent extends WeaponPayload {
+  ownerId: string;
+  team: Team;
+  cooldown: number; // seconds (runtime convenience)
   lastFiredAt?: number;
-  power: number; // base damage
-  accuracy?: number; // 0..1
-  spread?: number; // radians
-  ammo?: { clip: number; clipSize: number; reserve: number };
-  energyCost?: number;
-  projectilePrefab?: string;
-  aoeRadius?: number;
-  beamParams?: { duration?: number; width?: number; tickInterval?: number };
-  flags?: {
-    continuous?: boolean;
-    chargeable?: boolean;
-    burst?: boolean;
-    homing?: boolean;
+  spread?: number; // legacy radians convenience
+  ammo?: WeaponAmmo;
+  beamParams?: WeaponBeamParams;
+  flags?: WeaponFlags & {
+    friendlyFire?: boolean;
   };
 }
 
@@ -33,19 +31,20 @@ export interface WeaponStateComponent {
 
 export interface ProjectileComponent {
   sourceWeaponId: string;
-  ownerId: number;
+  ownerId: string;
   damage: number;
-  team: "red" | "blue";
+  team: Team;
+  ownerTeam?: Team;
   aoeRadius?: number;
   lifespan: number;
   spawnTime: number;
   speed?: number;
-  homing?: { turnSpeed: number; targetId?: number };
+  homing?: { turnSpeed: number; targetId?: number | string };
 }
 
 export interface BeamComponent {
   sourceWeaponId: string;
-  ownerId: number;
+  ownerId: string;
   firedAt: number;
   origin: [number, number, number];
   direction: [number, number, number];
@@ -58,7 +57,7 @@ export interface BeamComponent {
 }
 
 export interface DamageEvent {
-  sourceId: number;
+  sourceId: string | number;
   weaponId?: string;
   targetId?: number;
   position?: [number, number, number];

--- a/src/robots/spawnControls.ts
+++ b/src/robots/spawnControls.ts
@@ -1,6 +1,7 @@
 import {
   createRobotEntity,
   type Entity,
+  getGameplayId,
   notifyEntityChanged,
   resetWorld,
   type Team,
@@ -75,7 +76,7 @@ export function spawnRobot(
   const initialWeapon = {
     id: `weapon_${team}_${weaponType}_${spawnIndex}`,
     type: weaponType,
-    ownerId: -1, // will be corrected after entity is created
+    ownerId: "pending", // will be corrected after entity is created
     team,
     ...weaponProfiles[weaponType],
   } as WeaponComponent;
@@ -94,7 +95,8 @@ export function spawnRobot(
 
   // Now that the entity has an id, fix the ownerId to the correct value.
   if (robot.weapon) {
-    robot.weapon.ownerId = robot.id as number;
+    const gameplayId = getGameplayId(robot) ?? String(robot.id ?? "");
+    robot.weapon.ownerId = gameplayId;
   }
 
   return robot;

--- a/src/systems/DamageSystem.ts
+++ b/src/systems/DamageSystem.ts
@@ -1,7 +1,11 @@
 import type { World } from "miniplex";
 
 import type { Entity } from "../ecs/miniplexStore";
-import { getEntityById, notifyEntityChanged } from "../ecs/miniplexStore";
+import {
+  getEntityById,
+  getGameplayId,
+  notifyEntityChanged,
+} from "../ecs/miniplexStore";
 import type { DamageEvent } from "../ecs/weapons";
 
 type RigidBodyLike = {
@@ -57,6 +61,12 @@ export function damageSystem(
         const killerEntity = getEntityById(damageEvent.sourceId) as
           | Entity
           | undefined;
+        killerTeam = killerEntity?.team as string | undefined;
+      } else if (typeof damageEvent.sourceId === "string") {
+        const killerEntity = Array.from(world.entities).find((candidate) => {
+          const entity = candidate as Entity & { team?: string };
+          return getGameplayId(entity) === damageEvent.sourceId;
+        }) as Entity | undefined;
         killerTeam = killerEntity?.team as string | undefined;
       }
 


### PR DESCRIPTION
## Summary
- refactor `miniplexStore` to add gameplay IDs, new entity typing, and invulnerability helpers while normalizing component initialization
- align weapon, projectile, and beam types around deterministic string identifiers and update spawn controls plus core systems to consume the new ownership semantics
- adjust damage handling to resolve killer teams from gameplay IDs and mark the relevant implementation tasks as complete

## Testing
- npx vitest run tests/contracts/hitscanSystem.contract.test.ts *(fails: hitscanSystem contract harness invokes the system with an object argument so `weaponFiredEvents` is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe49cf40c832a9536fc4eedcf1011