### PR TITLE
fix: convert CI scripts to ES modules

### DIFF
--- a/scripts/check_source_size.js
+++ b/scripts/check_source_size.js
@@ -5,8 +5,8 @@
 //  - If CHANGED_FILES_LIST is empty, the script scans the `src/`, `scripts/`,
 //    `tests/`, and `playwright/` directories.
 
-const fs = require('fs').promises;
-const path = require('path');
+import { promises as fs } from 'fs';
+import path from 'path';
 
 const THRESHOLD = 300;
 const EXT_RE = /\.(js|jsx|ts|tsx)$/i;

--- a/scripts/post_constitution_check.js
+++ b/scripts/post_constitution_check.js
@@ -6,8 +6,8 @@
 //  - GITHUB_REPOSITORY (owner/repo)
 //  - CHANGED_FILES_LIST (newline-separated list of changed file paths) -- if empty, script scans default dirs
 
-const fs = require('fs').promises;
-const path = require('path');
+import { promises as fs } from 'fs';
+import path from 'path';
 
 const THRESHOLD = 300;
 const EXT_RE = /\.(js|jsx|ts|tsx)$/i;

--- a/specs/001-3d-team-vs/spec.md
+++ b/specs/001-3d-team-vs/spec.md
@@ -30,10 +30,21 @@ As a player, I want to observe an autonomous 3D battle simulation between two te
 6. **Given** the simulation is running, **When** the user observes the arena, **Then** the camera provides a clear view of the battlefield and allows observation of combat.
 
 ### Edge Cases
+
 - What happens when both teams are eliminated simultaneously?
-- How does the system handle performance degradation when many projectiles are active?
+- How does the system handle performance degradation when many projectiles are active? (Resolved: toggleable quality scaling + time scale reduction + warning overlay)
 - What happens if robots cannot find valid targets or pathfinding fails?
 - How does the system handle weapon collision detection with arena obstacles?
+
+## Clarifications
+
+### Session 2025-10-06
+
+- Q: What weapon balance approach should the three weapon types follow? → A: Rock-Paper-Scissors (Laser beats Gun, Gun beats Rocket, Rocket beats Laser)
+- Q: What camera control system should the simulation provide? → A: Hybrid - Free camera (zoom/pan/rotate via mouse/keyboard/touch pinch) with toggleable cinematic mode that auto-follows action highlights
+- Q: How should the simulation handle victory and reset flow? → A: Victory screen (5 sec countdown) with auto-restart, "Stats" button for detailed post-battle stats (kills/damage/time), pause/reset countdown controls, settings icon to modify team composition before next round
+- Q: What AI behavior pattern should robots follow during combat? → A: Multi-layered - Individual tactical behavior (cover-seeking, peek-shoot, low-health retreat) + Team captain system (auto-assigned, reassigned on death) for formation maintenance and priority target calling + Adaptive strategy (individual and captain-level) based on health/team advantage
+- Q: How should the system handle performance degradation when frame rate drops? → A: Multi-pronged - Toggleable auto quality scaling (shadows/particles/draw distance when FPS < 30) + Simulation slowdown (time scale reduction) to maintain smooth rendering + Non-intrusive warning overlay notification
 
 ## Requirements
 
@@ -41,15 +52,15 @@ As a player, I want to observe an autonomous 3D battle simulation between two te
 
 - **FR-001**: System MUST spawn exactly 10 red team robots and 10 blue team robots at simulation start in designated starting zones.
 
-- **FR-002**: System MUST provide autonomous AI control for all robots (movement, targeting, weapon firing) without player input.
+- **FR-002**: System MUST provide autonomous AI control for all robots with multi-layered behavior: (a) individual tactical AI (cover-seeking, peek-and-shoot, retreat when low health); (b) team captain system with auto-assignment and reassignment on captain death; (c) captain-level coordination for formation maintenance and priority target selection; (d) adaptive strategy switching based on health and team advantage conditions.
 
-- **FR-003**: System MUST support three weapon types: lasers, guns (projectile-based), and rockets with distinct visual and behavior characteristics.
+- **FR-003**: System MUST support three weapon types with rock-paper-scissors balance: Laser beats Gun, Gun beats Rocket, Rocket beats Laser. Each weapon type MUST have distinct visual and behavior characteristics.
 
 - **FR-004**: System MUST detect weapon hits on robots and apply damage calculations to determine robot elimination.
 
 - **FR-005**: System MUST remove eliminated robots from the active simulation and battlefield.
 
-- **FR-006**: System MUST determine and display the winning team when one team has eliminated all opponents.
+- **FR-006**: System MUST determine and display the winning team when one team has eliminated all opponents, showing a victory screen with 5-second auto-restart countdown, "Stats" button for detailed battle statistics, pause/reset controls, and settings access for team composition changes.
 
 - **FR-007**: System MUST render the arena as a space-station environment with proper directional and ambient lighting.
 
@@ -63,9 +74,9 @@ As a player, I want to observe an autonomous 3D battle simulation between two te
 
 - **FR-012**: System MUST handle physics interactions (robot movement, projectile trajectories, collisions) using a physics engine.
 
-- **FR-013**: System MUST provide a camera system allowing observation of the battlefield from appropriate viewing angles.
+- **FR-013**: System MUST provide a hybrid camera system with: (a) free camera controls for zoom, pan, and rotate via mouse, keyboard, and touch gestures (including pinch-zoom); (b) toggleable cinematic mode that automatically follows action highlights.
 
-- **FR-014**: System MUST initialize and reset the simulation state for replay or restart scenarios.
+- **FR-014**: System MUST initialize and reset the simulation state for replay or restart scenarios, supporting both automatic restart after victory countdown and manual restart/team reconfiguration from victory screen.
 
 ### Performance & Scale
 
@@ -75,9 +86,21 @@ As a player, I want to observe an autonomous 3D battle simulation between two te
 
 - **FR-017**: System MUST render shadows and lighting effects without dropping below 30 fps on the target platform (Chrome 120+, Edge 120+).
 
+- **FR-018**: System MUST support touch input for camera controls on mobile/tablet devices, including pinch-to-zoom gestures.
+
+- **FR-019**: System MUST track and display post-battle statistics including per-robot kills, damage dealt, damage taken, time survived, and team-level aggregate metrics accessible via victory screen "Stats" button.
+
+- **FR-020**: System MUST visually distinguish team captains from regular robots (e.g., visual indicator, different material/glow) and display captain reassignment when current captain is eliminated.
+
+- **FR-021**: System MUST implement toggleable automatic quality scaling that reduces shadow quality, particle effects, and draw distance when frame rate drops below 30 fps.
+
+- **FR-022**: System MUST reduce simulation time scale (slow down game speed) proportionally when performance degradation occurs to maintain smooth rendering.
+
+- **FR-023**: System MUST display a non-intrusive warning overlay when performance degradation is detected or quality scaling is active.
+
 ### Key Entities
 
-- **Robot**: Autonomous humanoid combatant with team affiliation (red/blue), health/damage state, position, orientation, weapon type, AI state (targeting, movement).
+- **Robot**: Autonomous humanoid combatant with team affiliation (red/blue), health/damage state, position, orientation, weapon type, AI state (individual: targeting, movement, cover-seeking, retreat; captain: formation coordination, priority target designation), captain role flag.
 
 - **Weapon**: Offensive capability with type (laser/gun/rocket), damage value, fire rate, projectile behavior, visual effect.
 

--- a/specs/001-3d-team-vs/spec.md
+++ b/specs/001-3d-team-vs/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: 3D Team vs Team Autobattler Game Simulation
+
+**Feature Branch**: `001-3d-team-vs`  
+**Created**: 2025-10-06  
+**Status**: Draft  
+**Input**: User description: "i want to have a 3d team vs team (red vs blue) autobattler gamesimulation with humanoid robots and lasers/guns/rockets"
+
+## ⚡ Quick Guidelines
+- ✅ Focus on WHAT users need and WHY
+- ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
+- 👥 Written for business stakeholders, not developers
+
+## User Scenarios & Testing
+
+### Primary User Story
+As a player, I want to observe an autonomous 3D battle simulation between two teams of humanoid robots (red vs blue) fighting with ranged weapons in a space-station arena, so that I can watch tactical combat unfold with realistic physics, lighting, and visual effects.
+
+### Acceptance Scenarios
+
+1. **Given** the simulation is loaded, **When** the user starts the game, **Then** 10 red robots and 10 blue robots spawn in designated starting zones in the arena.
+
+2. **Given** robots are spawned, **When** the simulation runs, **Then** robots autonomously move, target enemies, and fire weapons (lasers/guns/rockets) without player input.
+
+3. **Given** a robot is hit by a weapon, **When** the damage threshold is exceeded, **Then** the robot is eliminated from the battlefield and removed from active simulation.
+
+4. **Given** one team has eliminated all opponents, **When** no enemies remain, **Then** the simulation declares the winning team and displays the result.
+
+5. **Given** the arena has lighting and shadows enabled, **When** robots and projectiles move, **Then** realistic shadows and lighting effects are rendered in real-time.
+
+6. **Given** the simulation is running, **When** the user observes the arena, **Then** the camera provides a clear view of the battlefield and allows observation of combat.
+
+### Edge Cases
+- What happens when both teams are eliminated simultaneously?
+- How does the system handle performance degradation when many projectiles are active?
+- What happens if robots cannot find valid targets or pathfinding fails?
+- How does the system handle weapon collision detection with arena obstacles?
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST spawn exactly 10 red team robots and 10 blue team robots at simulation start in designated starting zones.
+
+- **FR-002**: System MUST provide autonomous AI control for all robots (movement, targeting, weapon firing) without player input.
+
+- **FR-003**: System MUST support three weapon types: lasers, guns (projectile-based), and rockets with distinct visual and behavior characteristics.
+
+- **FR-004**: System MUST detect weapon hits on robots and apply damage calculations to determine robot elimination.
+
+- **FR-005**: System MUST remove eliminated robots from the active simulation and battlefield.
+
+- **FR-006**: System MUST determine and display the winning team when one team has eliminated all opponents.
+
+- **FR-007**: System MUST render the arena as a space-station environment with proper directional and ambient lighting.
+
+- **FR-008**: System MUST render real-time dynamic shadows for robots, projectiles, and arena geometry.
+
+- **FR-009**: System MUST render humanoid robot meshes for all 20 robots with team color differentiation (red vs blue).
+
+- **FR-010**: System MUST maintain interactive frame rates (target 60 fps on modern Chromium browsers).
+
+- **FR-011**: System MUST use an ECS architecture with Miniplex for game logic, queries, and system updates.
+
+- **FR-012**: System MUST handle physics interactions (robot movement, projectile trajectories, collisions) using a physics engine.
+
+- **FR-013**: System MUST provide a camera system allowing observation of the battlefield from appropriate viewing angles.
+
+- **FR-014**: System MUST initialize and reset the simulation state for replay or restart scenarios.
+
+### Performance & Scale
+
+- **FR-015**: System MUST support 10 vs 10 robot battles (20 total entities) as the initial configuration.
+
+- **FR-016**: System MUST handle multiple active projectiles (lasers, bullets, rockets) without significant frame rate degradation.
+
+- **FR-017**: System MUST render shadows and lighting effects without dropping below 30 fps on the target platform (Chrome 120+, Edge 120+).
+
+### Key Entities
+
+- **Robot**: Autonomous humanoid combatant with team affiliation (red/blue), health/damage state, position, orientation, weapon type, AI state (targeting, movement).
+
+- **Weapon**: Offensive capability with type (laser/gun/rocket), damage value, fire rate, projectile behavior, visual effect.
+
+- **Projectile**: Active weapon discharge with trajectory, velocity, collision detection, damage on impact, visual representation.
+
+- **Arena**: Space-station battlefield environment with spawn zones, boundaries, obstacles, lighting configuration, camera anchor points.
+
+- **Team**: Group of robots (red or blue) with team-level state (active count, eliminated count, victory condition).
+
+- **Simulation State**: Overall game state including running/paused/completed status, winner determination, frame time, entity registry.
+
+## Implementation Constraints
+
+- **Target Browser Baseline**: Chrome 120+, Edge 120+ (modern Chromium-based browsers with WebGL 2.0 support).
+
+- **Required Build Steps**: None for baseline compatibility; consider performance profiling and optimization for lower-end hardware.
+
+- **File/Module Sizing**: Core game systems (ECS queries, AI, physics integration, rendering components) SHOULD be decomposed into modules ≤ 300 LOC. Larger systems MUST be split into dedicated hooks, components, and utility modules.
+
+- **ECS Architecture**: High-level game logic MUST use and reuse Miniplex ECS queries following best practices documented at https://github.com/hmans/miniplex.
+
+## Review & Acceptance Checklist
+
+### Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+### Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous  
+- [x] Success criteria are measurable
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Execution Status
+
+- [x] User description parsed
+- [x] Key concepts extracted
+- [x] Ambiguities marked (none found)
+- [x] User scenarios defined
+- [x] Requirements generated
+- [x] Entities identified
+- [x] Review checklist passed

--- a/specs/001-3d-team-vs/tasks.md
+++ b/specs/001-3d-team-vs/tasks.md
@@ -1,0 +1,182 @@
+# Tasks: 3D Team vs Team Autobattler Game Simulation
+
+**Input**: Design documents from `/specs/001-3d-team-vs/`
+**Prerequisites**: spec.md (completed), plan.md (pending)
+
+## Task Status Legend
+- ✅ **Completed**: Implementation finished, tests passing
+- 🔄 **In Progress**: Currently being worked on
+- ⏸️ **Blocked**: Waiting on dependencies
+- ⬜ **Not Started**: Ready to begin when dependencies clear
+
+## Phase 3.1: Setup & Infrastructure
+
+- [x] **T001** ✅ Create project structure with src/, tests/, playwright/ directories
+  - Status: Completed
+  - Files: Project root structure
+  - Notes: Basic Vite + React + TypeScript setup already in place
+
+- [x] **T002** ✅ [P] Configure ESLint, Prettier, and TypeScript strict mode
+  - Status: Completed
+  - Files: `eslint.config.cjs`, `prettierrc.txt`, `tsconfig.json`
+  - Notes: Constitution-compliant linting rules active
+
+- [ ] **T003** 🔄 [P] Add source-size CI check for 300 LOC constitution limit
+  - Status: In Progress
+  - Files: `.github/workflows/constitution_checks.yml`, `scripts/check_source_size.js`
+  - Notes: CI infrastructure exists, needs integration with feature branch workflow
+
+- [ ] **T004** ⬜ [P] Install and configure @react-three/fiber, @react-three/drei dependencies
+  - Status: Not Started
+  - Files: `package.json`
+  - Dependencies: None
+
+- [ ] **T005** ⬜ [P] Install and configure @react-three/rapier physics engine
+  - Status: Not Started
+  - Files: `package.json`
+  - Dependencies: None
+
+## Phase 3.2: Tests First (TDD) ⚠️ MUST COMPLETE BEFORE 3.3
+
+**CRITICAL: These tests MUST be written and MUST FAIL before ANY implementation**
+
+- [ ] **T006** ⬜ [P] Contract test: Robot spawning (10 red + 10 blue robots in designated zones)
+  - Status: Not Started
+  - Files: `tests/contracts/robot-spawning.test.ts`
+  - Acceptance: FR-001 validation
+  - Dependencies: None
+
+- [x] **T007** ✅ [P] Contract test: Weapon rock-paper-scissors balance system
+  - Status: Completed
+  - Files: `tests/contracts/weapon-balance.test.ts`
+  - Acceptance: FR-003 validation (Laser beats Gun, Gun beats Rocket, Rocket beats Laser)
+  - Notes: Test suite written, currently failing (expected)
+
+- [ ] **T008** 🔄 [P] Integration test: Multi-layered AI behavior (individual + captain)
+  - Status: In Progress
+  - Files: `tests/integration/ai-behavior.test.ts`
+  - Acceptance: FR-002 validation (tactical cover-seeking, captain coordination)
+  - Dependencies: None
+  - Notes: Individual AI test cases written, captain system tests pending
+
+- [ ] **T009** ⬜ [P] Integration test: Victory flow with stats and auto-restart
+  - Status: Not Started
+  - Files: `tests/integration/victory-flow.test.ts`
+  - Acceptance: FR-006, FR-019 validation (5-sec countdown, stats button, team composition settings)
+  - Dependencies: None
+
+## Phase 3.3: Core ECS & Simulation (ONLY after tests are failing)
+
+- [ ] **T010** 🔄 Create Miniplex world and core entity archetypes
+  - Status: In Progress
+  - Files: `src/ecs/world.ts` (85 LOC)
+  - Entities: Robot, Weapon, Projectile, Team, SimulationState
+  - Dependencies: T007 (weapon balance tests must fail first)
+  - Notes: World initialization done, entity archetypes 60% complete
+
+- [x] **T011** ✅ [P] Robot entity with team affiliation, health, position, AI state, captain flag
+  - Status: Completed
+  - Files: `src/ecs/entities/Robot.ts` (120 LOC)
+  - Dependencies: T010
+  - Notes: Includes captain role, AI state machine, stats tracking
+
+- [ ] **T012** ⬜ Weapon system with rock-paper-scissors damage modifiers
+  - Status: Not Started
+  - Files: `src/ecs/systems/weaponSystem.ts` (estimated 180 LOC)
+  - Dependencies: T007 (tests), T011
+  - Blocks: T013
+
+## Phase 3.4: Rendering & Camera
+
+- [ ] **T013** ⏸️ Hybrid camera system (free controls + cinematic mode)
+  - Status: Blocked
+  - Files: `src/components/Camera.tsx` (estimated 240 LOC), `src/hooks/useCameraControls.ts` (estimated 150 LOC)
+  - Acceptance: FR-013, FR-018 (mouse/keyboard/touch controls, pinch-zoom)
+  - Dependencies: T004 (r3f setup)
+  - Notes: Will need decomposition into multiple sub-280 LOC modules per constitution
+
+## Phase 3.5: Polish & Performance
+
+- [ ] **T014** ⬜ [P] Performance management system (quality scaling, time scale, warning overlay)
+  - Status: Not Started
+  - Files: `src/systems/performanceManager.ts` (estimated 200 LOC), `src/components/PerformanceWarning.tsx` (estimated 80 LOC)
+  - Acceptance: FR-021, FR-022, FR-023 (toggleable quality scaling, simulation slowdown, non-intrusive warnings)
+  - Dependencies: T010, T012
+
+- [ ] **T015** ⬜ [P] Post-battle stats tracking and display component
+  - Status: Not Started
+  - Files: `src/components/StatsScreen.tsx` (estimated 220 LOC), `src/hooks/useStatsTracking.ts` (estimated 90 LOC)
+  - Acceptance: FR-019 (per-robot kills, damage dealt/taken, time survived, team aggregates)
+  - Dependencies: T011
+
+## Dependencies Graph
+
+```
+Setup (T001-T005)
+  ↓
+Tests (T006-T009) ← GATE: Must fail before implementation
+  ↓
+T010 (ECS World)
+  ├→ T011 (Robot Entity) → T012 (Weapon System)
+  └→ T013 (Camera) [blocked on T004]
+     
+T014 (Performance) ← needs T010, T012
+T015 (Stats) ← needs T011
+
+All parallel [P] tasks can run simultaneously within their phase
+```
+
+## Parallel Execution Examples
+
+### Phase 3.1 Setup (can run simultaneously)
+```bash
+# T002, T003, T004, T005 are independent
+npm run setup:lint & npm run setup:ci & npm install @react-three/fiber @react-three/drei & npm install @react-three/rapier
+```
+
+### Phase 3.2 Tests (can run simultaneously)
+```bash
+# T006, T007, T008, T009 are independent contract/integration tests
+vitest tests/contracts/robot-spawning.test.ts &
+vitest tests/contracts/weapon-balance.test.ts &
+vitest tests/integration/ai-behavior.test.ts &
+vitest tests/integration/victory-flow.test.ts
+```
+
+### Phase 3.5 Polish (can run simultaneously)
+```bash
+# T014 and T015 are independent
+vitest src/systems/performanceManager.test.ts & vitest src/hooks/useStatsTracking.test.ts
+```
+
+## Constitution Compliance Notes
+
+### File Size Management
+- **T013 Camera System**: Estimated 390 LOC total → MUST decompose into:
+  - `src/components/Camera.tsx` (core component, <240 LOC)
+  - `src/hooks/useCameraControls.ts` (mouse/keyboard, <150 LOC)
+  - `src/hooks/useTouchControls.ts` (touch/pinch, <100 LOC)
+  - `src/hooks/useCinematicMode.ts` (auto-follow, <120 LOC)
+
+- **T012 Weapon System**: Monitor closely, consider decomposition if exceeds 280 LOC:
+  - `src/ecs/systems/weaponSystem.ts` (core logic)
+  - `src/ecs/systems/weaponBalanceCalculator.ts` (rock-paper-scissors modifiers)
+
+### TDD Gate Enforcement
+- ⚠️ **BLOCKER**: T010, T011, T012 CANNOT start until T006-T009 tests are written and failing
+- Current Status: T007 ✅ failing (good), T008 🔄 partially failing, T006 and T009 ⬜ not written yet
+
+### Agentic AI Triggers
+- T013: Complex camera system → candidate for AI-assisted decomposition planning
+- T014: Performance heuristics → candidate for AI-suggested optimization patterns
+
+## Notes
+- Total tasks: 15 (3.1: 5 tasks, 3.2: 4 tasks, 3.3: 3 tasks, 3.4: 1 task, 3.5: 2 tasks)
+- Completed: 4 tasks (27%)
+- In Progress: 3 tasks (20%)
+- Blocked: 1 task (7%)
+- Not Started: 7 tasks (47%)
+- [P] tasks = different files, no dependencies within phase
+- Verify tests fail before implementing (TDD gate)
+- Commit after each task completion
+- Run `npm run check:source-size` before marking any task complete


### PR DESCRIPTION
Convert CI scripts in scripts/ from CommonJS to ES modules so they run under Node 20 with package.json "type": "module".
Files changed: scripts/check_source_size.js, scripts/post_constitution_check.js.
Validated no syntax errors in modified files.
