### PR TITLE
Implement projectile entity model and renderer

### DIFF
--- a/specs/001-3d-team-vs/tasks.md
+++ b/specs/001-3d-team-vs/tasks.md
@@ -84,11 +84,11 @@ Single-project structure (per plan.md):
 
 ### Entity Models (6 tasks - can parallelize)
 
-- [ ] T014 [P] Robot entity model in `src/ecs/entities/Robot.ts`: define Robot archetype with id, team, position, rotation, velocity, health, maxHealth, weaponType, isCaptain, aiState (behaviorMode, targetId, coverPosition, lastFireTime, formationOffset), stats (kills, damageDealt, damageTaken, timeAlive, shotsFired). Validate health bounds, team values, captain uniqueness. Export type and validation functions. (~120 LOC)
+- [x] T014 [P] Robot entity model in `src/ecs/entities/Robot.ts`: define Robot archetype with id, team, position, rotation, velocity, health, maxHealth, weaponType, isCaptain, aiState (behaviorMode, targetId, coverPosition, lastFireTime, formationOffset), stats (kills, damageDealt, damageTaken, timeAlive, shotsFired). Validate health bounds, team values, captain uniqueness. Export type and validation functions. (~120 LOC)
 
 - [ ] T015 [P] Weapon entity model in `src/ecs/entities/Weapon.ts`: define Weapon config with type, baseDamage, fireRate, projectileSpeed, effectiveRange, visualEffect. Include type-specific properties table and damage multiplier matrix (rock-paper-scissors). Export WeaponConfig type and getDamageMultiplier() function. (~80 LOC)
 
-- [ ] T016 [P] Projectile entity model in `src/ecs/entities/Projectile.ts`: define Projectile archetype with id, ownerId, weaponType, position, velocity, damage, distanceTraveled, maxDistance, spawnTime, maxLifetime. Include despawn condition checks. Export type and shouldDespawn() function. (~90 LOC)
+- [x] T016 [P] Projectile entity model in `src/ecs/entities/Projectile.ts`: define Projectile archetype with id, ownerId, weaponType, position, velocity, damage, distanceTraveled, maxDistance, spawnTime, maxLifetime. Include despawn condition checks. Export type and shouldDespawn() function. (~90 LOC)
 
 - [ ] T017 [P] Team entity model in `src/ecs/entities/Team.ts`: define Team archetype with name, activeRobots, eliminatedRobots, captainId, spawnZone (center, radius, spawnPoints), aggregateStats (totalKills, totalDamageDealt, totalDamageTaken, averageHealthRemaining, weaponDistribution). Export type and victory condition check. (~110 LOC)
 
@@ -120,9 +120,9 @@ Single-project structure (per plan.md):
 
 ### r3f 3D Components (6 tasks - can parallelize after core)
 
-- [ ] T028 [P] Robot rendering component in `src/components/Robot.tsx`: render procedural robot mesh (THREE.BoxGeometry for MVP), apply team color material, display health bar (floating above robot), captain visual indicator (glow/outline), sync position/rotation from ECS. Use useFrame for interpolation only. Depends on T014, T020. (~150 LOC)
+- [x] T028 [P] Robot rendering component in `src/components/Robot.tsx`: render procedural robot mesh (THREE.BoxGeometry for MVP), apply team color material, display health bar (floating above robot), captain visual indicator (glow/outline), sync position/rotation from ECS. Use useFrame for interpolation only. Depends on T014, T020. (~150 LOC)
 
-- [ ] T029 [P] Projectile rendering component in `src/components/Projectile.tsx`: render projectile based on weaponType (beam for laser, tracer for gun, exhaust for rocket), apply visual effects, sync position from ECS. Use GPU instancing for multiple projectiles. Depends on T016, T020. (~120 LOC)
+- [x] T029 [P] Projectile rendering component in `src/components/Projectile.tsx`: render projectile based on weaponType (beam for laser, tracer for gun, exhaust for rocket), apply visual effects, sync position from ECS. Use GPU instancing for multiple projectiles. Depends on T016, T020. (~120 LOC)
 
 - [ ] T030 [P] Arena rendering component in `src/components/Arena.tsx`: render space-station environment (procedural floor/walls), spawn zone markers, obstacles (cover boxes), setup directional + ambient lighting, configure shadows. Use Arena entity config. Depends on T018, T020. (~180 LOC)
 

--- a/src/components/Projectile.tsx
+++ b/src/components/Projectile.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { InstancedMesh, Matrix4, Quaternion as ThreeQuaternion, Vector3 as ThreeVector3 } from 'three';
+
+import type { Projectile } from '../ecs/entities/Projectile';
+import type { WeaponType } from '../types';
+
+export interface ProjectileInstancesProps {
+  projectiles: Projectile[];
+}
+
+const PROJECTILE_TYPES: WeaponType[] = ['laser', 'gun', 'rocket'];
+
+interface ProjectileVisualConfig {
+  color: string;
+  emissive?: string;
+  emissiveIntensity: number;
+  scale: [number, number, number];
+  geometry: 'cylinder' | 'box' | 'cone';
+}
+
+const VISUAL_CONFIG: Record<WeaponType, ProjectileVisualConfig> = {
+  laser: {
+    color: '#22d3ee',
+    emissive: '#a855f7',
+    emissiveIntensity: 0.9,
+    scale: [0.1, 0.1, 0.6],
+    geometry: 'cylinder',
+  },
+  gun: {
+    color: '#f97316',
+    emissive: '#9a3412',
+    emissiveIntensity: 0.3,
+    scale: [0.12, 0.12, 0.4],
+    geometry: 'box',
+  },
+  rocket: {
+    color: '#facc15',
+    emissive: '#f59e0b',
+    emissiveIntensity: 0.6,
+    scale: [0.15, 0.15, 0.5],
+    geometry: 'cone',
+  },
+};
+
+type GroupedProjectiles = Record<WeaponType, Projectile[]>;
+
+function groupProjectiles(projectiles: Projectile[]): GroupedProjectiles {
+  return projectiles.reduce<GroupedProjectiles>(
+    (acc, projectile) => {
+      acc[projectile.weaponType].push(projectile);
+      return acc;
+    },
+    {
+      laser: [],
+      gun: [],
+      rocket: [],
+    }
+  );
+}
+
+const tempMatrix = new Matrix4();
+const tempPosition = new ThreeVector3();
+const tempQuaternion = new ThreeQuaternion();
+const tempScale = new ThreeVector3();
+
+export function ProjectileInstances({ projectiles }: ProjectileInstancesProps) {
+  const grouped = useMemo(() => groupProjectiles(projectiles), [projectiles]);
+
+  const instancedRefs = useRef<Record<WeaponType, InstancedMesh | null>>({
+    laser: null,
+    gun: null,
+    rocket: null,
+  });
+
+  useEffect(() => {
+    PROJECTILE_TYPES.forEach((type) => {
+      const mesh = instancedRefs.current[type];
+      if (!mesh) {
+        return;
+      }
+
+      const config = VISUAL_CONFIG[type];
+      const items = grouped[type];
+
+      mesh.count = items.length;
+      items.forEach((projectile, index) => {
+        tempPosition.set(projectile.position.x, projectile.position.y, projectile.position.z);
+        tempQuaternion.set(0, 0, 0, 1);
+        tempScale.set(config.scale[0], config.scale[1], config.scale[2]);
+
+        tempMatrix.compose(tempPosition, tempQuaternion, tempScale);
+        mesh.setMatrixAt(index, tempMatrix);
+      });
+      mesh.instanceMatrix.needsUpdate = true;
+    });
+  }, [grouped]);
+
+  const meshes = useMemo(() => PROJECTILE_TYPES.map((type) => {
+    const config = VISUAL_CONFIG[type];
+
+    return (
+      <instancedMesh
+        key={type}
+        ref={(value) => {
+          instancedRefs.current[type] = value;
+        }}
+        name={`projectiles-${type}`}
+        args={[undefined, undefined, grouped[type].length]}
+        frustumCulled={false}
+      >
+        {config.geometry === 'cylinder' ? (
+          <cylinderGeometry args={[0.05, 0.05, 0.8, 8]} />
+        ) : config.geometry === 'cone' ? (
+          <coneGeometry args={[0.12, 0.8, 8]} />
+        ) : (
+          <boxGeometry args={[0.2, 0.2, 0.6]} />
+        )}
+        <meshStandardMaterial
+          color={config.color}
+          emissive={config.emissive}
+          emissiveIntensity={config.emissiveIntensity}
+        />
+      </instancedMesh>
+    );
+  }), [grouped]);
+
+  return <group name="projectiles">{meshes}</group>;
+}
+
+export default ProjectileInstances;

--- a/src/components/Robot.tsx
+++ b/src/components/Robot.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import type { Group } from 'three';
+
+import type { Robot as RobotEntity } from '../ecs/entities/Robot';
+import type { Quaternion, Vector3 } from '../types';
+import { lerpVector } from '../utils/math';
+
+export interface RobotProps {
+  robot: RobotEntity;
+  /**
+   * Interpolation factor applied during useFrame updates to smooth positional changes.
+   * Defaults to 0.2 which provides a responsive yet stable interpolation.
+   */
+  interpolationAlpha?: number;
+}
+
+const TEAM_COLORS = {
+  red: '#ff5f57',
+  blue: '#4a90e2',
+} as const;
+
+const MIN_HEALTH_SCALE = 0.01;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function lerpQuaternion(from: Quaternion, to: Quaternion, t: number): Quaternion {
+  const lerped = {
+    x: from.x + (to.x - from.x) * t,
+    y: from.y + (to.y - from.y) * t,
+    z: from.z + (to.z - from.z) * t,
+    w: from.w + (to.w - from.w) * t,
+  };
+
+  const length = Math.hypot(lerped.x, lerped.y, lerped.z, lerped.w) || 1;
+
+  return {
+    x: lerped.x / length,
+    y: lerped.y / length,
+    z: lerped.z / length,
+    w: lerped.w / length,
+  };
+}
+
+function getHealthColor(percentage: number): string {
+  if (percentage > 0.6) {
+    return '#4ade80';
+  }
+
+  if (percentage > 0.3) {
+    return '#facc15';
+  }
+
+  return '#f87171';
+}
+
+export function Robot({ robot, interpolationAlpha = 0.2 }: RobotProps) {
+  const groupRef = useRef<Group>(null);
+  const previousPosition = useRef<Vector3>({ ...robot.position });
+  const previousRotation = useRef<Quaternion>({ ...robot.rotation });
+
+  const teamColor = TEAM_COLORS[robot.team];
+
+  const healthPercentage = useMemo(() => {
+    if (robot.maxHealth <= 0) {
+      return 0;
+    }
+
+    return clamp(robot.health / robot.maxHealth, 0, 1);
+  }, [robot.health, robot.maxHealth]);
+
+  const healthColor = useMemo(
+    () => getHealthColor(healthPercentage),
+    [healthPercentage]
+  );
+
+  useFrame(() => {
+    const group = groupRef.current;
+    if (!group) {
+      return;
+    }
+
+    const nextPosition = lerpVector(previousPosition.current, robot.position, interpolationAlpha);
+    previousPosition.current = nextPosition;
+    group.position.set(nextPosition.x, nextPosition.y, nextPosition.z);
+
+    const nextRotation = lerpQuaternion(previousRotation.current, robot.rotation, interpolationAlpha);
+    previousRotation.current = nextRotation;
+    group.quaternion.set(nextRotation.x, nextRotation.y, nextRotation.z, nextRotation.w);
+  });
+
+  return (
+    <group
+      ref={groupRef}
+      name={`robot-${robot.id}`}
+      position={[robot.position.x, robot.position.y, robot.position.z]}
+      quaternion={[robot.rotation.x, robot.rotation.y, robot.rotation.z, robot.rotation.w]}
+    >
+      <mesh name="robot-body" castShadow receiveShadow>
+        <boxGeometry args={[1, 2, 1]} />
+        <meshStandardMaterial
+          color={teamColor}
+          emissive={robot.isCaptain ? '#ffd966' : '#000000'}
+          emissiveIntensity={robot.isCaptain ? 0.6 : 0}
+        />
+      </mesh>
+
+      {robot.isCaptain ? (
+        <mesh name="captain-indicator" position={[0, 1.2, 0]}>
+          <sphereGeometry args={[0.35, 16, 16]} />
+          <meshBasicMaterial color="#ffd966" />
+        </mesh>
+      ) : null}
+
+      <group name="health-bar" position={[0, 1.4, 0]}>
+        <mesh name="health-bar-background">
+          <planeGeometry args={[1.2, 0.15]} />
+          <meshBasicMaterial color="#111827" />
+        </mesh>
+        <mesh
+          name="health-bar-fill"
+          position={[(healthPercentage - 1) / 2, 0, 0.01]}
+          scale={[Math.max(healthPercentage, MIN_HEALTH_SCALE), 1, 1]}
+        >
+          <planeGeometry args={[1, 0.1]} />
+          <meshBasicMaterial color={healthColor} />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+export default Robot;

--- a/src/ecs/entities/Projectile.ts
+++ b/src/ecs/entities/Projectile.ts
@@ -1,0 +1,57 @@
+import type { Vector3, WeaponType } from '../../types';
+
+export interface Projectile {
+  id: string;
+  ownerId: string;
+  weaponType: WeaponType;
+  position: Vector3;
+  velocity: Vector3;
+  damage: number;
+  distanceTraveled: number;
+  maxDistance: number;
+  spawnTime: number;
+  maxLifetime: number;
+}
+
+export interface ProjectileInput extends Projectile {}
+
+function clampPositive(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+
+  return value;
+}
+
+function normalizeVector(vector: Vector3): Vector3 {
+  return {
+    x: Number.isFinite(vector.x) ? vector.x : 0,
+    y: Number.isFinite(vector.y) ? vector.y : 0,
+    z: Number.isFinite(vector.z) ? vector.z : 0,
+  };
+}
+
+export function normalizeProjectile(input: ProjectileInput): Projectile {
+  return {
+    ...input,
+    position: normalizeVector(input.position),
+    velocity: normalizeVector(input.velocity),
+    damage: clampPositive(input.damage, 1),
+    distanceTraveled: Math.max(0, input.distanceTraveled),
+    maxDistance: clampPositive(input.maxDistance, 1),
+    maxLifetime: clampPositive(input.maxLifetime, 0.1),
+    spawnTime: Math.max(0, input.spawnTime),
+  };
+}
+
+export function createProjectile(input: ProjectileInput): Projectile {
+  return normalizeProjectile(input);
+}
+
+export function shouldDespawn(projectile: Projectile, currentTime: number): boolean {
+  if (projectile.distanceTraveled >= projectile.maxDistance) {
+    return true;
+  }
+
+  return currentTime - projectile.spawnTime >= projectile.maxLifetime;
+}

--- a/src/ecs/entities/Robot.ts
+++ b/src/ecs/entities/Robot.ts
@@ -1,0 +1,112 @@
+import type { AIState, Quaternion, RobotStats, Team, Vector3, WeaponType } from '../../types';
+
+export interface Robot {
+  id: string;
+  team: Team;
+  position: Vector3;
+  rotation: Quaternion;
+  velocity: Vector3;
+  health: number;
+  maxHealth: number;
+  weaponType: WeaponType;
+  isCaptain: boolean;
+  aiState: AIState;
+  stats: RobotStats;
+}
+
+export interface RobotInput extends Robot {}
+
+const VALID_TEAMS: readonly Team[] = ['red', 'blue'];
+
+function assertValidTeam(team: Team): void {
+  if (!VALID_TEAMS.includes(team)) {
+    throw new Error(`Invalid team: ${team}`);
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function sanitizeVector(vector: Vector3): Vector3 {
+  return {
+    x: Number.isFinite(vector.x) ? vector.x : 0,
+    y: Number.isFinite(vector.y) ? Math.max(0, vector.y) : 0,
+    z: Number.isFinite(vector.z) ? vector.z : 0,
+  };
+}
+
+function sanitizeQuaternion(quaternion: Quaternion): Quaternion {
+  const length = Math.hypot(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+  if (length === 0) {
+    return { x: 0, y: 0, z: 0, w: 1 };
+  }
+
+  return {
+    x: quaternion.x / length,
+    y: quaternion.y / length,
+    z: quaternion.z / length,
+    w: quaternion.w / length,
+  };
+}
+
+export function normalizeRobot(input: RobotInput): Robot {
+  assertValidTeam(input.team);
+
+  const maxHealth = Math.max(1, input.maxHealth);
+  const clampedHealth = clamp(input.health, 0, maxHealth);
+
+  return {
+    ...input,
+    team: input.team,
+    maxHealth,
+    health: clampedHealth,
+    position: sanitizeVector(input.position),
+    rotation: sanitizeQuaternion(input.rotation),
+    velocity: sanitizeVector(input.velocity),
+    stats: {
+      kills: Math.max(0, input.stats.kills),
+      damageDealt: Math.max(0, input.stats.damageDealt),
+      damageTaken: Math.max(0, input.stats.damageTaken),
+      timeAlive: Math.max(0, input.stats.timeAlive),
+      shotsFired: Math.max(0, input.stats.shotsFired),
+    },
+    aiState: {
+      ...input.aiState,
+      lastFireTime: Math.max(0, input.aiState.lastFireTime),
+      formationOffset: sanitizeVector(input.aiState.formationOffset),
+      coverPosition: input.aiState.coverPosition
+        ? sanitizeVector(input.aiState.coverPosition)
+        : null,
+    },
+  };
+}
+
+export function createRobot(input: RobotInput): Robot {
+  return normalizeRobot(input);
+}
+
+export function hasValidCaptainDistribution(robots: Robot[]): boolean {
+  const activeCounts: Record<Team, number> = { red: 0, blue: 0 };
+  const captainCounts: Record<Team, number> = { red: 0, blue: 0 };
+
+  robots.forEach((robot) => {
+    const normalized = normalizeRobot(robot);
+    if (normalized.health <= 0) {
+      return;
+    }
+
+    activeCounts[normalized.team] += 1;
+    if (normalized.isCaptain) {
+      captainCounts[normalized.team] += 1;
+    }
+  });
+
+  return VALID_TEAMS.every((team) => {
+    if (activeCounts[team] === 0) {
+      return captainCounts[team] === 0;
+    }
+
+    return captainCounts[team] === 1;
+  });
+}

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,11 @@
+import type { Vector3 } from '../types';
+
+export function lerpVector(from: Vector3, to: Vector3, alpha: number): Vector3 {
+  const clampedAlpha = Math.min(1, Math.max(0, alpha));
+
+  return {
+    x: from.x + (to.x - from.x) * clampedAlpha,
+    y: from.y + (to.y - from.y) * clampedAlpha,
+    z: from.z + (to.z - from.z) * clampedAlpha,
+  };
+}

--- a/tests/unit/components/Projectile.test.tsx
+++ b/tests/unit/components/Projectile.test.tsx
@@ -1,0 +1,77 @@
+import { create } from '@react-three/test-renderer';
+import { Matrix4, Vector3 as ThreeVector3 } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import type { Projectile } from '../../../src/ecs/entities/Projectile';
+
+function createProjectile(overrides: Partial<Projectile> = {}): Projectile {
+  return {
+    id: overrides.id ?? `proj-${Math.random()}`,
+    ownerId: overrides.ownerId ?? 'robot-1',
+    weaponType: overrides.weaponType ?? 'laser',
+    position: overrides.position ?? { x: 0, y: 0, z: 0 },
+    velocity: overrides.velocity ?? { x: 0, y: 0, z: 1 },
+    damage: overrides.damage ?? 10,
+    distanceTraveled: overrides.distanceTraveled ?? 0,
+    maxDistance: overrides.maxDistance ?? 50,
+    spawnTime: overrides.spawnTime ?? 0,
+    maxLifetime: overrides.maxLifetime ?? 2,
+  };
+}
+
+describe('Projectile component', () => {
+  it('groups projectiles by weapon type and uses instancing', async () => {
+    const projectiles: Projectile[] = [
+      createProjectile({ id: 'laser-1', weaponType: 'laser', position: { x: 1, y: 0.5, z: -2 } }),
+      createProjectile({ id: 'laser-2', weaponType: 'laser', position: { x: -2, y: 1, z: 0 } }),
+      createProjectile({ id: 'rocket-1', weaponType: 'rocket', position: { x: 3, y: 0, z: 4 } }),
+    ];
+
+    const { ProjectileInstances } = await import('../../../src/components/Projectile');
+
+    const renderer = await create(<ProjectileInstances projectiles={projectiles} />);
+    const groupInstance = renderer.scene.children[0] as any;
+    const group = groupInstance.object ?? groupInstance._fiber?.object;
+    const laserMesh = group.getObjectByName('projectiles-laser');
+    const rocketMesh = group.getObjectByName('projectiles-rocket');
+
+    expect(laserMesh).toBeDefined();
+    expect(rocketMesh).toBeDefined();
+    expect(laserMesh.count).toBe(2);
+    expect(rocketMesh.count).toBe(1);
+
+    const matrix = new Matrix4();
+    const position = new ThreeVector3();
+    laserMesh.getMatrixAt(0, matrix);
+    position.setFromMatrixPosition(matrix);
+
+    expect(position.x).toBeCloseTo(1);
+    expect(position.y).toBeCloseTo(0.5);
+    expect(position.z).toBeCloseTo(-2);
+
+    await renderer.unmount();
+  });
+
+  it('applies unique visual characteristics per weapon type', async () => {
+    const projectiles: Projectile[] = [
+      createProjectile({ weaponType: 'laser' }),
+      createProjectile({ weaponType: 'gun' }),
+      createProjectile({ weaponType: 'rocket' }),
+    ];
+
+    const { ProjectileInstances } = await import('../../../src/components/Projectile');
+
+    const renderer = await create(<ProjectileInstances projectiles={projectiles} />);
+    const groupInstance = renderer.scene.children[0] as any;
+    const group = groupInstance.object ?? groupInstance._fiber?.object;
+    const laserMesh = group.getObjectByName('projectiles-laser');
+    const gunMesh = group.getObjectByName('projectiles-gun');
+    const rocketMesh = group.getObjectByName('projectiles-rocket');
+
+    expect(laserMesh.material.emissiveIntensity).toBeGreaterThan(gunMesh.material.emissiveIntensity);
+    expect(gunMesh.material.color.getHexString()).toBe('f97316');
+    expect(rocketMesh.material.color.getHexString()).toBe('facc15');
+
+    await renderer.unmount();
+  });
+});

--- a/tests/unit/components/Robot.test.tsx
+++ b/tests/unit/components/Robot.test.tsx
@@ -1,0 +1,112 @@
+import { create } from '@react-three/test-renderer';
+import { describe, expect, it } from 'vitest';
+
+import { createRobot } from '../../../src/ecs/entities/Robot';
+import type { Robot as RobotEntity } from '../../../src/ecs/entities/Robot';
+import type { Vector3 } from '../../../src/types';
+
+function createTestRobot(overrides: Partial<RobotEntity> = {}): RobotEntity {
+  const basePosition: Vector3 = { x: 1, y: 2, z: 3 };
+  const baseRotation = { x: 0, y: 0, z: 0, w: 1 } as const;
+
+  return createRobot({
+    id: overrides.id ?? 'robot-1',
+    team: overrides.team ?? 'red',
+    position: overrides.position ?? basePosition,
+    rotation: overrides.rotation ?? baseRotation,
+    velocity: overrides.velocity ?? { x: 0, y: 0, z: 0 },
+    weaponType: overrides.weaponType ?? 'laser',
+    isCaptain: overrides.isCaptain ?? false,
+    maxHealth: overrides.maxHealth ?? 100,
+    health: overrides.health ?? 100,
+    aiState:
+      overrides.aiState ??
+      {
+        behaviorMode: 'aggressive',
+        targetId: null,
+        coverPosition: null,
+        lastFireTime: 0,
+        formationOffset: { x: 0, y: 0, z: 0 },
+      },
+    stats:
+      overrides.stats ??
+      {
+        kills: 0,
+        damageDealt: 0,
+        damageTaken: 0,
+        timeAlive: 0,
+        shotsFired: 0,
+      },
+  });
+}
+
+describe('Robot component', () => {
+  it('positions the robot group using entity coordinates', async () => {
+    const robot = createTestRobot({ position: { x: 4, y: 0, z: -2 } });
+
+    // Lazy import so the component can be created after test file is evaluated
+    const { Robot } = await import('../../../src/components/Robot');
+
+    const renderer = await create(<Robot robot={robot} />);
+    const robotInstance = renderer.scene.children[0];
+    const testInstance = robotInstance as any;
+    const groupObject = testInstance.object ?? testInstance._fiber?.object;
+
+    expect(groupObject).toBeDefined();
+    expect(groupObject.position.x).toBeCloseTo(4);
+    expect(groupObject.position.y).toBeCloseTo(0);
+    expect(groupObject.position.z).toBeCloseTo(-2);
+
+    await renderer.unmount();
+  });
+
+  it('applies team color to the robot material', async () => {
+    const robot = createTestRobot({ id: 'robot-blue', team: 'blue' });
+    const { Robot } = await import('../../../src/components/Robot');
+
+    const renderer = await create(<Robot robot={robot} />);
+    const robotInstance = renderer.scene.children[0];
+    const testInstance = robotInstance as any;
+    const groupObject = testInstance.object ?? testInstance._fiber?.object;
+    const bodyMesh = groupObject?.getObjectByName?.('robot-body');
+
+    expect(bodyMesh).toBeDefined();
+    const material = (bodyMesh as any).material;
+    expect(material.color.getHexString()).toBe('4a90e2');
+
+    await renderer.unmount();
+  });
+
+  it('renders health bar scaled to health percentage', async () => {
+    const robot = createTestRobot({ id: 'robot-damaged', health: 45, maxHealth: 100 });
+    const { Robot } = await import('../../../src/components/Robot');
+
+    const renderer = await create(<Robot robot={robot} />);
+    const robotInstance = renderer.scene.children[0];
+    const testInstance = robotInstance as any;
+    const groupObject = testInstance.object ?? testInstance._fiber?.object;
+    const healthBarGroup = groupObject?.getObjectByName?.('health-bar');
+    const healthFill = healthBarGroup?.getObjectByName?.('health-bar-fill');
+
+    expect(healthFill).toBeDefined();
+    // 45 health out of 100 = 0.45 scale factor
+    expect(healthFill.scale.x).toBeCloseTo(0.45, 2);
+
+    await renderer.unmount();
+  });
+
+  it('shows captain indicator when robot is captain', async () => {
+    const robot = createTestRobot({ id: 'captain', isCaptain: true });
+    const { Robot } = await import('../../../src/components/Robot');
+
+    const renderer = await create(<Robot robot={robot} />);
+    const robotInstance = renderer.scene.children[0];
+    const testInstance = robotInstance as any;
+    const groupObject = testInstance.object ?? testInstance._fiber?.object;
+    const captainIndicator = groupObject?.getObjectByName?.('captain-indicator');
+
+    expect(captainIndicator).toBeDefined();
+
+    await renderer.unmount();
+  });
+});

--- a/tests/unit/entities/ProjectileEntity.test.ts
+++ b/tests/unit/entities/ProjectileEntity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { createProjectile, shouldDespawn } from '../../../src/ecs/entities/Projectile';
+
+const baseProjectile = {
+  id: 'proj-1',
+  ownerId: 'robot-1',
+  weaponType: 'laser' as const,
+  position: { x: 0, y: 0, z: 0 },
+  velocity: { x: 0, y: 0, z: 1 },
+  damage: 10,
+  distanceTraveled: 0,
+  maxDistance: 50,
+  spawnTime: 0,
+  maxLifetime: 2,
+};
+
+describe('Projectile entity model', () => {
+  it('creates projectile with normalized values', () => {
+    const projectile = createProjectile({
+      ...baseProjectile,
+      damage: -5,
+      distanceTraveled: -10,
+    });
+
+    expect(projectile.damage).toBeGreaterThan(0);
+    expect(projectile.distanceTraveled).toBeGreaterThanOrEqual(0);
+  });
+
+  it('determines despawn by lifetime and distance', () => {
+    const projectile = createProjectile(baseProjectile);
+
+    expect(shouldDespawn(projectile, 1)).toBe(false);
+    expect(
+      shouldDespawn(
+        {
+          ...projectile,
+          distanceTraveled: 60,
+        },
+        1
+      )
+    ).toBe(true);
+    expect(
+      shouldDespawn(
+        projectile,
+        projectile.spawnTime + projectile.maxLifetime + 0.1
+      )
+    ).toBe(true);
+  });
+});

--- a/tests/unit/entities/RobotEntity.test.ts
+++ b/tests/unit/entities/RobotEntity.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Vector3 } from '../../../src/types';
+import { createRobot, hasValidCaptainDistribution, normalizeRobot } from '../../../src/ecs/entities/Robot';
+
+const basePosition: Vector3 = { x: 0, y: 0, z: 0 };
+const baseRotation = { x: 0, y: 0, z: 0, w: 1 } as const;
+
+function createTestRobot(overrides: Partial<Parameters<typeof createRobot>[0]> = {}) {
+  return createRobot({
+    id: 'robot-1',
+    team: 'red',
+    position: basePosition,
+    rotation: baseRotation,
+    velocity: { x: 0, y: 0, z: 0 },
+    weaponType: 'laser',
+    maxHealth: 100,
+    health: 100,
+    isCaptain: false,
+    aiState: {
+      behaviorMode: 'aggressive',
+      targetId: null,
+      coverPosition: null,
+      lastFireTime: 0,
+      formationOffset: { x: 0, y: 0, z: 0 },
+    },
+    stats: {
+      kills: 0,
+      damageDealt: 0,
+      damageTaken: 0,
+      timeAlive: 0,
+      shotsFired: 0,
+    },
+    ...overrides,
+  });
+}
+
+describe('Robot entity model', () => {
+  it('clamps health within bounds', () => {
+    const robot = createTestRobot({ health: 150 });
+
+    expect(robot.health).toBe(100);
+  });
+
+  it('normalizes provided robot state to enforce invariants', () => {
+    const normalized = normalizeRobot({
+      id: 'robot-2',
+      team: 'blue',
+      position: { x: 2, y: -5, z: 3 },
+      rotation: baseRotation,
+      velocity: { x: 0, y: 0, z: 0 },
+      weaponType: 'rocket',
+      maxHealth: 80,
+      health: -10,
+      isCaptain: true,
+      aiState: {
+        behaviorMode: 'defensive',
+        targetId: 'enemy-1',
+        coverPosition: null,
+        lastFireTime: 100,
+        formationOffset: { x: 1, y: 0, z: -1 },
+      },
+      stats: {
+        kills: 1,
+        damageDealt: 10,
+        damageTaken: 20,
+        timeAlive: 30,
+        shotsFired: 4,
+      },
+    });
+
+    expect(normalized.position.y).toBeGreaterThanOrEqual(0);
+    expect(normalized.health).toBeGreaterThanOrEqual(0);
+    expect(normalized.health).toBeLessThanOrEqual(normalized.maxHealth);
+    expect(normalized.team).toBe('blue');
+  });
+
+  it('throws when provided with an invalid team', () => {
+    expect(() =>
+      createTestRobot({
+        team: 'green' as never,
+      })
+    ).toThrowError(/Invalid team/i);
+  });
+
+  it('validates captain distribution per team', () => {
+    const robots = [
+      createTestRobot({ id: 'r1', team: 'red', isCaptain: true }),
+      createTestRobot({ id: 'r2', team: 'red', isCaptain: false }),
+      createTestRobot({ id: 'b1', team: 'blue', isCaptain: true }),
+    ];
+
+    expect(hasValidCaptainDistribution(robots)).toBe(true);
+
+    const invalid = [
+      createTestRobot({ id: 'r1', team: 'red', isCaptain: true }),
+      createTestRobot({ id: 'r2', team: 'red', isCaptain: true }),
+    ];
+
+    expect(hasValidCaptainDistribution(invalid)).toBe(false);
+  });
+});

--- a/tests/unit/utils/math.test.ts
+++ b/tests/unit/utils/math.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { lerpVector } from '../../../src/utils/math';
+
+describe('math utils', () => {
+  it('linearly interpolates between vectors', () => {
+    const start = { x: 0, y: 0, z: 0 };
+    const end = { x: 10, y: -5, z: 2 };
+
+    const result = lerpVector(start, end, 0.25);
+
+    expect(result).toEqual({ x: 2.5, y: -1.25, z: 0.5 });
+  });
+});


### PR DESCRIPTION
## Summary
- add normalized Robot and Projectile entity models with captain distribution helper
- provide a reusable vector interpolation utility and instanced projectile renderer with weapon-specific visuals
- cover the new entities and renderer with Vitest unit tests and mark the corresponding tasks complete

## Testing
- npm test -- --run tests/unit/entities/RobotEntity.test.ts tests/unit/entities/ProjectileEntity.test.ts tests/unit/utils/math.test.ts tests/unit/components/Robot.test.tsx tests/unit/components/Projectile.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e34a5b5b1c832aa6ede81b3773b62e