### PR TITLE
Add arena rendering and cinematic UI utilities

### DIFF
--- a/specs/001-3d-team-vs/tasks.md
+++ b/specs/001-3d-team-vs/tasks.md
@@ -138,19 +138,19 @@ Single-project structure (per plan.md):
 
 - [x] T029 [P] Projectile rendering component in `src/components/Projectile.tsx`: render projectile based on weaponType (beam for laser, tracer for gun, exhaust for rocket), apply visual effects, sync position from ECS. Use GPU instancing for multiple projectiles. Depends on T016, T020. (~120 LOC)
 
-- [ ] T030 [P] Arena rendering component in `src/components/Arena.tsx`: render space-station environment (procedural floor/walls), spawn zone markers, obstacles (cover boxes), setup directional + ambient lighting, configure shadows. Use Arena entity config. Depends on T018, T020. (~180 LOC)
+- [x] T030 [P] Arena rendering component in `src/components/Arena.tsx`: render space-station environment (procedural floor/walls), spawn zone markers, obstacles (cover boxes), setup directional + ambient lighting, configure shadows. Use Arena entity config. Depends on T018, T020. (~180 LOC)
 
 - [ ] T031 Camera system - Free camera hook in `src/hooks/useCameraControls.ts`: implement orbit controls (mouse drag), zoom (scroll wheel), pan (right-click drag), keyboard controls (arrow keys for rotate, W/S for zoom, A/D for strafe). Query arena for boundaries. Depends on T018, T020. (~150 LOC)
 
 - [ ] T032 Camera system - Touch controls hook in `src/hooks/useTouchControls.ts`: implement single finger drag (orbit), pinch-to-zoom, two-finger drag (pan). Integrate with useCameraControls for unified control state. Depends on T031. (~100 LOC)
 
-- [ ] T033 Camera system - Cinematic mode hook in `src/hooks/useCinematicMode.ts`: implement auto-follow combat hotspots (query robots with lowest health or highest damage), smooth camera transitions, toggleable mode (keyboard "C" or button). Query robots and calculate action centers. Depends on T014, T020, T031. (~120 LOC)
+- [x] T033 Camera system - Cinematic mode hook in `src/hooks/useCinematicMode.ts`: implement auto-follow combat hotspots (query robots with lowest health or highest damage), smooth camera transitions, toggleable mode (keyboard "C" or button). Query robots and calculate action centers. Depends on T014, T020, T031. (~120 LOC)
 
 ### UI Components (2 tasks)
 
-- [ ] T034 Victory screen component in `src/components/ui/VictoryScreen.tsx`: display winner (red/blue/draw), 5-second countdown timer, "Stats" button to open post-battle metrics modal, pause/reset countdown controls, settings icon for team composition changes. Use Zustand for UI state. Depends on T019, T020. (~140 LOC)
+- [x] T034 Victory screen component in `src/components/ui/VictoryScreen.tsx`: display winner (red/blue/draw), 5-second countdown timer, "Stats" button to open post-battle metrics modal, pause/reset countdown controls, settings icon for team composition changes. Use Zustand for UI state. Depends on T019, T020. (~140 LOC)
 
-- [ ] T035 Performance overlay component in `src/components/ui/PerformanceOverlay.tsx`: display FPS counter, warning message when quality scaling active, toggleable auto-scaling checkbox. Read SimulationState.performanceStats. Use Zustand for visibility toggle. Depends on T019, T020. (~90 LOC)
+- [x] T035 Performance overlay component in `src/components/ui/PerformanceOverlay.tsx`: display FPS counter, warning message when quality scaling active, toggleable auto-scaling checkbox. Read SimulationState.performanceStats. Use Zustand for visibility toggle. Depends on T019, T020. (~90 LOC)
 
 ---
 

--- a/src/components/Arena.tsx
+++ b/src/components/Arena.tsx
@@ -1,0 +1,139 @@
+import type { ArenaEntity } from '../ecs/entities/Arena';
+import type { Team } from '../types';
+
+export interface ArenaProps {
+  arena: ArenaEntity;
+}
+
+const TEAM_COLORS: Record<Team, string> = {
+  red: '#ff5f57',
+  blue: '#4a90e2',
+};
+
+function renderWalls(arena: ArenaEntity) {
+  const halfWidth = arena.dimensions.x / 2;
+  const halfDepth = arena.dimensions.z / 2;
+  const wallHeight = arena.dimensions.y / 2;
+  const wallThickness = 2;
+
+  return (
+    <group name="arena-walls">
+      <mesh
+        name="arena-wall-north"
+        position={[0, wallHeight, -halfDepth]}
+        castShadow
+        receiveShadow
+      >
+        <boxGeometry args={[arena.dimensions.x, arena.dimensions.y, wallThickness]} />
+        <meshStandardMaterial color="#20263b" />
+      </mesh>
+      <mesh
+        name="arena-wall-south"
+        position={[0, wallHeight, halfDepth]}
+        castShadow
+        receiveShadow
+      >
+        <boxGeometry args={[arena.dimensions.x, arena.dimensions.y, wallThickness]} />
+        <meshStandardMaterial color="#20263b" />
+      </mesh>
+      <mesh
+        name="arena-wall-east"
+        position={[halfWidth, wallHeight, 0]}
+        castShadow
+        receiveShadow
+      >
+        <boxGeometry args={[wallThickness, arena.dimensions.y, arena.dimensions.z]} />
+        <meshStandardMaterial color="#1b2236" />
+      </mesh>
+      <mesh
+        name="arena-wall-west"
+        position={[-halfWidth, wallHeight, 0]}
+        castShadow
+        receiveShadow
+      >
+        <boxGeometry args={[wallThickness, arena.dimensions.y, arena.dimensions.z]} />
+        <meshStandardMaterial color="#1b2236" />
+      </mesh>
+    </group>
+  );
+}
+
+function renderSpawnZones(arena: ArenaEntity) {
+  return (Object.entries(arena.spawnZones) as [Team, ArenaEntity['spawnZones'][Team]][]).map(([team, zone]) => (
+    <group key={team} name={`spawn-zone-${team}-group`}>
+      <mesh
+        name={`spawn-zone-${team}`}
+        position={[zone.center.x, 0.02, zone.center.z]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
+        <ringGeometry args={[zone.radius * 0.6, zone.radius, 64]} />
+        <meshBasicMaterial color={TEAM_COLORS[team]} transparent opacity={0.3} />
+      </mesh>
+      {zone.spawnPoints.map((point, index) => (
+        <mesh
+          key={`${team}-${index}`}
+          name={`spawn-point-${team}-${index}`}
+          position={[point.x, 0.4, point.z]}
+          castShadow
+        >
+          <sphereGeometry args={[0.4, 16, 16]} />
+          <meshStandardMaterial
+            color={TEAM_COLORS[team]}
+            emissive={TEAM_COLORS[team]}
+            emissiveIntensity={0.35}
+          />
+        </mesh>
+      ))}
+    </group>
+  ));
+}
+
+function renderObstacles(arena: ArenaEntity) {
+  return arena.obstacles.map((obstacle, index) => (
+    <mesh
+      key={`${obstacle.position.x}-${obstacle.position.z}-${index}`}
+      name={`arena-obstacle-${index}`}
+      position={[obstacle.position.x, obstacle.position.y + obstacle.dimensions.y / 2, obstacle.position.z]}
+      castShadow
+      receiveShadow
+    >
+      <boxGeometry args={[obstacle.dimensions.x, obstacle.dimensions.y, obstacle.dimensions.z]} />
+      <meshStandardMaterial color={obstacle.isCover ? '#374151' : '#1f2937'} />
+    </mesh>
+  ));
+}
+
+export function Arena({ arena }: ArenaProps) {
+  return (
+    <group name="arena">
+      <ambientLight
+        name="arena-ambient-light"
+        color={arena.lightingConfig.ambientColor}
+        intensity={arena.lightingConfig.ambientIntensity}
+      />
+      <directionalLight
+        name="arena-directional-light"
+        color={arena.lightingConfig.directionalColor}
+        intensity={arena.lightingConfig.directionalIntensity}
+        position={[0, arena.dimensions.y, arena.dimensions.z / 2]}
+        castShadow={arena.lightingConfig.shadowsEnabled}
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+      />
+
+      <mesh name="arena-floor" rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[arena.dimensions.x, arena.dimensions.z]} />
+        <meshStandardMaterial color="#0f172a" metalness={0.1} roughness={0.8} />
+      </mesh>
+
+      {renderWalls(arena)}
+
+      <group name="arena-spawn-zones">{renderSpawnZones(arena)}</group>
+
+      <group name="arena-obstacles">{renderObstacles(arena)}</group>
+    </group>
+  );
+}
+
+export default Arena;

--- a/src/components/ui/PerformanceOverlay.tsx
+++ b/src/components/ui/PerformanceOverlay.tsx
@@ -1,0 +1,75 @@
+import type { ChangeEvent } from 'react';
+
+import type { PerformanceStats } from '../../types';
+import { useUIStore } from '../../store/uiStore';
+
+export interface PerformanceOverlayProps {
+  stats: PerformanceStats;
+  autoScalingEnabled: boolean;
+  onToggleAutoScaling: (enabled: boolean) => void;
+}
+
+export function PerformanceOverlay({ stats, autoScalingEnabled, onToggleAutoScaling }: PerformanceOverlayProps) {
+  const visible = useUIStore((state) => state.performanceOverlayVisible);
+  const setVisible = useUIStore((state) => state.setPerformanceOverlayVisible);
+
+  if (!visible) {
+    return (
+      <div
+        aria-label="Performance Overlay"
+        style={{ position: 'absolute', bottom: '1rem', right: '1rem' }}
+      >
+        <button type="button" onClick={() => setVisible(true)}>
+          Show Overlay
+        </button>
+      </div>
+    );
+  }
+
+  const handleCheckbox = (event: ChangeEvent<HTMLInputElement>) => {
+    onToggleAutoScaling(event.target.checked);
+  };
+
+  return (
+    <aside
+      aria-label="Performance Overlay"
+      style={{
+        position: 'absolute',
+        bottom: '1rem',
+        right: '1rem',
+        padding: '1rem',
+        background: 'rgba(15, 23, 42, 0.88)',
+        color: 'white',
+        borderRadius: '0.75rem',
+        minWidth: '220px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+      }}
+    >
+      <div>
+        <strong>{Math.round(stats.currentFPS)} fps</strong>
+        <div style={{ opacity: 0.75 }}>Avg: {Math.round(stats.averageFPS)} fps</div>
+      </div>
+
+      {stats.qualityScalingActive ? (
+        <div style={{ color: '#f97316', fontWeight: 600 }}>Performance mode active</div>
+      ) : null}
+
+      <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <input
+          type="checkbox"
+          checked={autoScalingEnabled}
+          onChange={handleCheckbox}
+        />
+        Auto quality scaling
+      </label>
+
+      <button type="button" onClick={() => setVisible(false)}>
+        Hide Overlay
+      </button>
+    </aside>
+  );
+}
+
+export default PerformanceOverlay;

--- a/src/components/ui/VictoryScreen.tsx
+++ b/src/components/ui/VictoryScreen.tsx
@@ -1,0 +1,110 @@
+import type { SimulationState } from '../../ecs/entities/SimulationState';
+import { useUIStore } from '../../store/uiStore';
+
+export interface VictoryScreenProps {
+  simulation: Pick<
+    SimulationState,
+    'status' | 'winner' | 'autoRestartCountdown' | 'countdownPaused'
+  >;
+  onTogglePause?: (paused: boolean) => void;
+  onResetCountdown?: () => void;
+  onShowStats?: () => void;
+  onShowSettings?: () => void;
+}
+
+function formatWinnerMessage(winner: VictoryScreenProps['simulation']['winner']): string {
+  if (winner === 'draw' || winner === null) {
+    return 'Battle Ends in a Draw';
+  }
+
+  return winner === 'red' ? 'Red Team Wins' : 'Blue Team Wins';
+}
+
+function formatCountdown(countdown: number | null): string {
+  if (countdown === null) {
+    return 'Auto-restart pending';
+  }
+
+  const seconds = Math.max(0, Math.ceil(countdown));
+  return `Auto-restart in ${seconds}s`;
+}
+
+export function VictoryScreen({
+  simulation,
+  onTogglePause,
+  onResetCountdown,
+  onShowStats,
+  onShowSettings,
+}: VictoryScreenProps) {
+  const isVisible = simulation.status === 'victory' || simulation.status === 'simultaneous-elimination';
+  const setStatsOpen = useUIStore((state) => state.setStatsOpen);
+  const setSettingsOpen = useUIStore((state) => state.setSettingsOpen);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const pauseLabel = simulation.countdownPaused ? 'Resume' : 'Pause';
+
+  const handlePauseClick = () => {
+    const next = !simulation.countdownPaused;
+    onTogglePause?.(next);
+  };
+
+  const handleResetClick = () => {
+    onResetCountdown?.();
+  };
+
+  const handleStatsClick = () => {
+    setStatsOpen(true);
+    onShowStats?.();
+  };
+
+  const handleSettingsClick = () => {
+    setSettingsOpen(true);
+    onShowSettings?.();
+  };
+
+  return (
+    <section
+      aria-label="Victory Screen"
+      className="victory-screen"
+      style={{
+        position: 'absolute',
+        top: '10%',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        padding: '1.5rem',
+        background: 'rgba(15, 23, 42, 0.9)',
+        color: 'white',
+        borderRadius: '1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        minWidth: '320px',
+      }}
+    >
+      <header>
+        <h2 style={{ fontSize: '1.75rem', margin: 0 }}>{formatWinnerMessage(simulation.winner)}</h2>
+        <p style={{ margin: '0.25rem 0 0', opacity: 0.8 }}>{formatCountdown(simulation.autoRestartCountdown)}</p>
+      </header>
+
+      <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+        <button type="button" onClick={handlePauseClick}>
+          {pauseLabel}
+        </button>
+        <button type="button" onClick={handleResetClick}>
+          Reset Countdown
+        </button>
+        <button type="button" onClick={handleStatsClick}>
+          Stats
+        </button>
+        <button type="button" onClick={handleSettingsClick}>
+          Settings
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export default VictoryScreen;

--- a/src/hooks/useCinematicMode.ts
+++ b/src/hooks/useCinematicMode.ts
@@ -1,0 +1,147 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import type { Robot } from '../ecs/entities/Robot';
+import type { Vector3 } from '../types';
+
+export interface UseCinematicModeOptions {
+  robots: Robot[];
+  initiallyActive?: boolean;
+  followStrength?: number;
+  maxFocusRobots?: number;
+  fallbackTarget?: Vector3;
+}
+
+export interface CinematicModeResult {
+  focus: Vector3;
+  isActive: boolean;
+  setActive: (active: boolean) => void;
+  toggle: () => void;
+  handleKeyDown: (event: Pick<KeyboardEvent, 'code'>) => void;
+  update: (deltaTime: number) => void;
+}
+
+const DEFAULT_TARGET: Vector3 = { x: 0, y: 0, z: 0 };
+const DEFAULT_STRENGTH = 0.12;
+const MAX_DELTA = 0.25;
+
+function lerp(current: number, target: number, alpha: number) {
+  return current + (target - current) * alpha;
+}
+
+function averageVectors(vectors: Vector3[]): Vector3 {
+  if (vectors.length === 0) {
+    return { ...DEFAULT_TARGET };
+  }
+
+  const sum = vectors.reduce(
+    (acc, value) => ({
+      x: acc.x + value.x,
+      y: acc.y + value.y,
+      z: acc.z + value.z,
+    }),
+    { x: 0, y: 0, z: 0 }
+  );
+
+  return {
+    x: sum.x / vectors.length,
+    y: sum.y / vectors.length,
+    z: sum.z / vectors.length,
+  };
+}
+
+function calculateIntensity(robot: Robot): number {
+  if (robot.health <= 0) {
+    return -Infinity;
+  }
+
+  const healthPressure = 1 - robot.health / Math.max(robot.maxHealth, 1);
+  const damageMomentum = robot.stats.damageDealt / 200;
+  const incomingDamage = robot.stats.damageTaken / 300;
+  const killWeight = robot.stats.kills * 0.2;
+
+  return healthPressure * 0.5 + damageMomentum * 0.3 + incomingDamage * 0.15 + killWeight;
+}
+
+export function useCinematicMode({
+  robots,
+  initiallyActive = false,
+  followStrength = DEFAULT_STRENGTH,
+  maxFocusRobots = 3,
+  fallbackTarget = DEFAULT_TARGET,
+}: UseCinematicModeOptions): CinematicModeResult {
+  const [isActive, setIsActive] = useState(initiallyActive);
+  const [focus, setFocus] = useState<Vector3>({ ...fallbackTarget });
+  const focusRef = useRef<Vector3>({ ...fallbackTarget });
+
+  const sortedRobots = useMemo(() => {
+    const scored = robots.map((robot) => ({ robot, intensity: calculateIntensity(robot) }));
+    const positive = scored.filter((entry) => entry.intensity > 0);
+    const pool = positive.length > 0 ? positive : scored;
+
+    const sorted = pool.sort((a, b) => b.intensity - a.intensity);
+    if (sorted.length === 0) {
+      return [];
+    }
+
+    const focusCutoff = Math.max(sorted[0].intensity * 0.5, 0);
+    const focused = sorted.filter((entry, index) => index === 0 || entry.intensity >= focusCutoff);
+
+    return focused
+      .slice(0, Math.max(1, maxFocusRobots))
+      .map((entry) => entry.robot);
+  }, [robots, maxFocusRobots]);
+
+  const hotspot = useMemo(() => {
+    const active = sortedRobots.filter((robot) => robot.health > 0);
+    if (active.length === 0) {
+      return { ...fallbackTarget };
+    }
+
+    return averageVectors(active.map((robot) => robot.position));
+  }, [sortedRobots, fallbackTarget]);
+
+  const setActive = useCallback((active: boolean) => {
+    setIsActive(active);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsActive((value) => !value);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: Pick<KeyboardEvent, 'code'>) => {
+      if (event.code === 'KeyC') {
+        toggle();
+      }
+    },
+    [toggle]
+  );
+
+  const update = useCallback(
+    (deltaTime: number) => {
+      if (!isActive) {
+        return;
+      }
+
+      const clampedDelta = Math.min(Math.max(deltaTime, 0), MAX_DELTA);
+      const normalizedAlpha = 1 - Math.pow(1 - followStrength, clampedDelta * 60);
+
+      focusRef.current = {
+        x: lerp(focusRef.current.x, hotspot.x, normalizedAlpha),
+        y: lerp(focusRef.current.y, hotspot.y, normalizedAlpha),
+        z: lerp(focusRef.current.z, hotspot.z, normalizedAlpha),
+      };
+      setFocus({ ...focusRef.current });
+    },
+    [followStrength, hotspot, isActive]
+  );
+
+  return {
+    focus,
+    isActive,
+    setActive,
+    toggle,
+    handleKeyDown,
+    update,
+  };
+}

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+interface UIState {
+  statsOpen: boolean;
+  settingsOpen: boolean;
+  performanceOverlayVisible: boolean;
+  setStatsOpen: (open: boolean) => void;
+  setSettingsOpen: (open: boolean) => void;
+  setPerformanceOverlayVisible: (visible: boolean) => void;
+  reset: () => void;
+}
+
+const initialState: Pick<UIState, 'statsOpen' | 'settingsOpen' | 'performanceOverlayVisible'> = {
+  statsOpen: false,
+  settingsOpen: false,
+  performanceOverlayVisible: true,
+};
+
+export const useUIStore = create<UIState>((set) => ({
+  ...initialState,
+  setStatsOpen: (open) => set({ statsOpen: open }),
+  setSettingsOpen: (open) => set({ settingsOpen: open }),
+  setPerformanceOverlayVisible: (visible) => set({ performanceOverlayVisible: visible }),
+  reset: () => set({ ...initialState }),
+}));
+
+export type { UIState };

--- a/tests/unit/components/Arena.test.tsx
+++ b/tests/unit/components/Arena.test.tsx
@@ -1,0 +1,96 @@
+import { create } from '@react-three/test-renderer';
+import { describe, expect, it } from 'vitest';
+
+import { createDefaultArena } from '../../../src/ecs/entities/Arena';
+
+type TestNode = {
+  object?: any;
+  _fiber?: { object?: any };
+  children?: TestNode[];
+};
+
+function extractObject(node: TestNode | undefined): any | undefined {
+  if (!node) {
+    return undefined;
+  }
+  return node.object ?? node._fiber?.object ?? node;
+}
+
+describe('Arena component', () => {
+  it('renders floor scaled to arena dimensions', async () => {
+    const arena = createDefaultArena();
+    const { Arena } = await import('../../../src/components/Arena');
+
+    const renderer = await create(<Arena arena={arena} />);
+    const rootNode = renderer.scene.children[0] as TestNode;
+    const group = extractObject(rootNode);
+
+    expect(group).toBeDefined();
+    const floor = group?.getObjectByName?.('arena-floor');
+
+    expect(floor).toBeDefined();
+    const geometryArgs = (floor as any)?.geometry?.parameters;
+    expect(geometryArgs?.width).toBeCloseTo(arena.dimensions.x);
+    expect(geometryArgs?.height).toBeCloseTo(arena.dimensions.z);
+
+    await renderer.unmount();
+  });
+
+  it('creates spawn zone markers for each team', async () => {
+    const arena = createDefaultArena();
+    const { Arena } = await import('../../../src/components/Arena');
+
+    const renderer = await create(<Arena arena={arena} />);
+    const rootNode = renderer.scene.children[0] as TestNode;
+    const group = extractObject(rootNode);
+
+    const redMarker = group?.getObjectByName?.('spawn-zone-red');
+    const blueMarker = group?.getObjectByName?.('spawn-zone-blue');
+
+    expect(redMarker?.position.x).toBeCloseTo(arena.spawnZones.red.center.x);
+    expect(redMarker?.position.z).toBeCloseTo(arena.spawnZones.red.center.z);
+    expect(blueMarker?.position.x).toBeCloseTo(arena.spawnZones.blue.center.x);
+    expect(blueMarker?.position.z).toBeCloseTo(arena.spawnZones.blue.center.z);
+
+    await renderer.unmount();
+  });
+
+  it('renders obstacle meshes for arena cover positions', async () => {
+    const arena = createDefaultArena();
+    const { Arena } = await import('../../../src/components/Arena');
+
+    const renderer = await create(<Arena arena={arena} />);
+    const rootNode = renderer.scene.children[0] as TestNode;
+    const group = extractObject(rootNode);
+
+    arena.obstacles.forEach((obstacle, index) => {
+      const mesh = group?.getObjectByName?.(`arena-obstacle-${index}`);
+      expect(mesh).toBeDefined();
+      expect(mesh?.position.x).toBeCloseTo(obstacle.position.x);
+      expect(mesh?.position.z).toBeCloseTo(obstacle.position.z);
+    });
+
+    await renderer.unmount();
+  });
+
+  it('configures lighting using arena lighting config', async () => {
+    const arena = createDefaultArena();
+    const { Arena } = await import('../../../src/components/Arena');
+
+    const renderer = await create(<Arena arena={arena} />);
+    const rootNode = renderer.scene.children[0] as TestNode;
+    const group = extractObject(rootNode);
+
+    const ambient = group?.getObjectByName?.('arena-ambient-light');
+    const directional = group?.getObjectByName?.('arena-directional-light');
+
+    expect(ambient).toBeDefined();
+    expect((ambient as any).intensity).toBeCloseTo(arena.lightingConfig.ambientIntensity);
+
+    expect(directional).toBeDefined();
+    expect((directional as any).intensity).toBeCloseTo(arena.lightingConfig.directionalIntensity);
+    expect((directional as any).castShadow).toBe(arena.lightingConfig.shadowsEnabled);
+
+    await renderer.unmount();
+  });
+});

--- a/tests/unit/components/ui/PerformanceOverlay.test.tsx
+++ b/tests/unit/components/ui/PerformanceOverlay.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PerformanceStats } from '../../../../src/types';
+
+const stats: PerformanceStats = {
+  currentFPS: 48,
+  averageFPS: 52,
+  qualityScalingActive: true,
+};
+
+describe('PerformanceOverlay', () => {
+  beforeEach(async () => {
+    const { useUIStore } = await import('../../../../src/store/uiStore');
+    useUIStore.getState().reset();
+  });
+
+  it('displays fps metrics and quality warning when visible', async () => {
+    const { PerformanceOverlay } = await import('../../../../src/components/ui/PerformanceOverlay');
+
+    render(<PerformanceOverlay stats={stats} autoScalingEnabled onToggleAutoScaling={() => {}} />);
+
+    expect(screen.getByText(/48 fps/i)).toBeInTheDocument();
+    expect(screen.getByText(/Avg: 52 fps/i)).toBeInTheDocument();
+    expect(screen.getByText(/Performance mode active/i)).toBeInTheDocument();
+  });
+
+  it('invokes callback when auto scaling checkbox toggled', async () => {
+    const onToggle = vi.fn();
+    const { PerformanceOverlay } = await import('../../../../src/components/ui/PerformanceOverlay');
+
+    render(<PerformanceOverlay stats={stats} autoScalingEnabled onToggleAutoScaling={onToggle} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Auto quality scaling/i }));
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('can hide overlay via zustand store toggle', async () => {
+    const { PerformanceOverlay } = await import('../../../../src/components/ui/PerformanceOverlay');
+    const { useUIStore } = await import('../../../../src/store/uiStore');
+
+    render(<PerformanceOverlay stats={stats} autoScalingEnabled onToggleAutoScaling={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /Hide Overlay/i }));
+
+    expect(useUIStore.getState().performanceOverlayVisible).toBe(false);
+  });
+});

--- a/tests/unit/components/ui/VictoryScreen.test.tsx
+++ b/tests/unit/components/ui/VictoryScreen.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SimulationState } from '../../../../src/ecs/entities/SimulationState';
+
+function createSimulationState(overrides: Partial<SimulationState> = {}): SimulationState {
+  return {
+    status: overrides.status ?? 'victory',
+    winner: overrides.winner ?? 'red',
+    frameTime: overrides.frameTime ?? 0,
+    totalFrames: overrides.totalFrames ?? 0,
+    simulationTime: overrides.simulationTime ?? 0,
+    timeScale: overrides.timeScale ?? 1,
+    victoryScreenStartTime: overrides.victoryScreenStartTime ?? 0,
+    autoRestartCountdown: overrides.autoRestartCountdown ?? 3.2,
+    countdownPaused: overrides.countdownPaused ?? false,
+    performanceStats:
+      overrides.performanceStats ??
+      {
+        currentFPS: 60,
+        averageFPS: 58,
+        qualityScalingActive: false,
+      },
+    pendingTeamConfig: overrides.pendingTeamConfig ?? null,
+    ui:
+      overrides.ui ??
+      {
+        statsOpen: false,
+        settingsOpen: false,
+      },
+  };
+}
+
+describe('VictoryScreen', () => {
+  beforeEach(async () => {
+    const { useUIStore } = await import('../../../../src/store/uiStore');
+    const reset = useUIStore.getState().reset;
+    reset();
+  });
+
+  it('displays the winning team and countdown timer', async () => {
+    const simulation = createSimulationState({ winner: 'blue', autoRestartCountdown: 4.6 });
+    const { VictoryScreen } = await import('../../../../src/components/ui/VictoryScreen');
+
+    render(<VictoryScreen simulation={simulation} />);
+
+    expect(screen.getByText(/Blue Team Wins/i)).toBeInTheDocument();
+    expect(screen.getByText(/Auto-restart in 5s/i)).toBeInTheDocument();
+  });
+
+  it('allows pausing the countdown', async () => {
+    const simulation = createSimulationState({ countdownPaused: false });
+    const onTogglePause = vi.fn();
+    const { VictoryScreen } = await import('../../../../src/components/ui/VictoryScreen');
+
+    render(<VictoryScreen simulation={simulation} onTogglePause={onTogglePause} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Pause/i }));
+    expect(onTogglePause).toHaveBeenCalledWith(true);
+  });
+
+  it('opens stats via zustand store when stats button clicked', async () => {
+    const simulation = createSimulationState();
+    const { VictoryScreen } = await import('../../../../src/components/ui/VictoryScreen');
+    const { useUIStore } = await import('../../../../src/store/uiStore');
+
+    render(<VictoryScreen simulation={simulation} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Stats/i }));
+    expect(useUIStore.getState().statsOpen).toBe(true);
+  });
+
+  it('opens settings via zustand store when settings button clicked', async () => {
+    const simulation = createSimulationState();
+    const { VictoryScreen } = await import('../../../../src/components/ui/VictoryScreen');
+    const { useUIStore } = await import('../../../../src/store/uiStore');
+
+    render(<VictoryScreen simulation={simulation} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Settings/i }));
+    expect(useUIStore.getState().settingsOpen).toBe(true);
+  });
+});

--- a/tests/unit/hooks/useCinematicMode.test.ts
+++ b/tests/unit/hooks/useCinematicMode.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { Robot } from '../../../src/ecs/entities/Robot';
+
+function createRobot(id: string, overrides: Partial<Robot> = {}): Robot {
+  return {
+    id,
+    team: overrides.team ?? 'red',
+    position: overrides.position ?? { x: 0, y: 0, z: 0 },
+    rotation: overrides.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+    velocity: overrides.velocity ?? { x: 0, y: 0, z: 0 },
+    health: overrides.health ?? 100,
+    maxHealth: overrides.maxHealth ?? 100,
+    weaponType: overrides.weaponType ?? 'laser',
+    isCaptain: overrides.isCaptain ?? false,
+    aiState:
+      overrides.aiState ??
+      {
+        behaviorMode: 'aggressive',
+        targetId: null,
+        coverPosition: null,
+        lastFireTime: 0,
+        formationOffset: { x: 0, y: 0, z: 0 },
+      },
+    stats:
+      overrides.stats ??
+      {
+        kills: 0,
+        damageDealt: 0,
+        damageTaken: 0,
+        timeAlive: 0,
+        shotsFired: 0,
+      },
+  };
+}
+
+describe('useCinematicMode', () => {
+  it('focuses on robots with the highest combat intensity', async () => {
+    const robots: Robot[] = [
+      createRobot('idle-1', { position: { x: -10, y: 0, z: -10 } }),
+      createRobot('hotspot-1', {
+        position: { x: 20, y: 0, z: 10 },
+        health: 30,
+        stats: { kills: 2, damageDealt: 200, damageTaken: 50, timeAlive: 40, shotsFired: 25 },
+      }),
+      createRobot('idle-2', { position: { x: -15, y: 0, z: 5 }, health: 90 }),
+    ];
+
+    const { useCinematicMode } = await import('../../../src/hooks/useCinematicMode');
+    const { result } = renderHook(() => useCinematicMode({ robots, initiallyActive: true, followStrength: 1 }));
+
+    act(() => {
+      result.current.update(0.016);
+    });
+
+    expect(result.current.focus.x).toBeCloseTo(20, 1);
+    expect(result.current.focus.z).toBeCloseTo(10, 1);
+  });
+
+  it('averages the top hotspots to compute focus', async () => {
+    const robots: Robot[] = [
+      createRobot('hotspot-a', {
+        position: { x: 20, y: 0, z: 20 },
+        health: 40,
+        stats: { kills: 1, damageDealt: 150, damageTaken: 100, timeAlive: 60, shotsFired: 40 },
+      }),
+      createRobot('hotspot-b', {
+        position: { x: 0, y: 0, z: -10 },
+        health: 50,
+        stats: { kills: 3, damageDealt: 220, damageTaken: 80, timeAlive: 55, shotsFired: 60 },
+      }),
+      createRobot('support', { position: { x: -40, y: 0, z: 0 }, health: 100 }),
+    ];
+
+    const { useCinematicMode } = await import('../../../src/hooks/useCinematicMode');
+    const { result } = renderHook(() => useCinematicMode({ robots, initiallyActive: true, followStrength: 1 }));
+
+    act(() => {
+      result.current.update(0.016);
+    });
+
+    expect(result.current.focus.x).toBeCloseTo((20 + 0) / 2, 1);
+    expect(result.current.focus.z).toBeCloseTo((20 - 10) / 2, 1);
+  });
+
+  it('toggles active state when pressing the C key', async () => {
+    const robots: Robot[] = [createRobot('one')];
+
+    const { useCinematicMode } = await import('../../../src/hooks/useCinematicMode');
+    const { result } = renderHook(() => useCinematicMode({ robots, initiallyActive: false, followStrength: 1 }));
+
+    act(() => {
+      result.current.handleKeyDown({ code: 'KeyC' } as KeyboardEvent);
+    });
+
+    expect(result.current.isActive).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement the Arena component to render the space-station floor, walls, spawn zones, obstacles, and arena lighting
- add a cinematic camera hook with Zustand-backed UI overlays for the victory screen and performance monitoring
- cover the new components and hooks with dedicated unit tests and update the feature task checklist

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e39a095b30832a9d51f23dd07000c7