### PR TITLE
Add physics sync and performance manager hooks

### DIFF
--- a/specs/001-3d-team-vs/tasks.md
+++ b/specs/001-3d-team-vs/tasks.md
@@ -140,9 +140,9 @@ Single-project structure (per plan.md):
 
 - [x] T030 [P] Arena rendering component in `src/components/Arena.tsx`: render space-station environment (procedural floor/walls), spawn zone markers, obstacles (cover boxes), setup directional + ambient lighting, configure shadows. Use Arena entity config. Depends on T018, T020. (~180 LOC)
 
-- [ ] T031 Camera system - Free camera hook in `src/hooks/useCameraControls.ts`: implement orbit controls (mouse drag), zoom (scroll wheel), pan (right-click drag), keyboard controls (arrow keys for rotate, W/S for zoom, A/D for strafe). Query arena for boundaries. Depends on T018, T020. (~150 LOC)
+- [x] T031 Camera system - Free camera hook in `src/hooks/useCameraControls.ts`: implement orbit controls (mouse drag), zoom (scroll wheel), pan (right-click drag), keyboard controls (arrow keys for rotate, W/S for zoom, A/D for strafe). Query arena for boundaries. Depends on T018, T020. (~150 LOC)
 
-- [ ] T032 Camera system - Touch controls hook in `src/hooks/useTouchControls.ts`: implement single finger drag (orbit), pinch-to-zoom, two-finger drag (pan). Integrate with useCameraControls for unified control state. Depends on T031. (~100 LOC)
+- [x] T032 Camera system - Touch controls hook in `src/hooks/useTouchControls.ts`: implement single finger drag (orbit), pinch-to-zoom, two-finger drag (pan). Integrate with useCameraControls for unified control state. Depends on T031. (~100 LOC)
 
 - [x] T033 Camera system - Cinematic mode hook in `src/hooks/useCinematicMode.ts`: implement auto-follow combat hotspots (query robots with lowest health or highest damage), smooth camera transitions, toggleable mode (keyboard "C" or button). Query robots and calculate action centers. Depends on T014, T020, T031. (~120 LOC)
 
@@ -158,9 +158,9 @@ Single-project structure (per plan.md):
 
 ### Integration (2 tasks)
 
-- [ ] T036 Physics sync integration in `src/systems/physicsSync.ts`: implement usePhysicsSync hook to read Rapier transform data and update ECS entity positions every frame, sync projectile trajectories, handle collision events (trigger damage system), remove physics bodies on entity despawn. Configure fixed timestep (60Hz). Depends on T014, T016, T020, T023. (~180 LOC)
+- [x] T036 Physics sync integration in `src/systems/physicsSync.ts`: implement usePhysicsSync hook to read Rapier transform data and update ECS entity positions every frame, sync projectile trajectories, handle collision events (trigger damage system), remove physics bodies on entity despawn. Configure fixed timestep (60Hz). Depends on T014, T016, T020, T023. (~180 LOC)
 
-- [ ] T037 Performance management system in `src/systems/performanceManager.ts`: monitor FPS (rolling average), activate quality scaling below 30 fps (disable shadows, reduce particles, adjust draw distance), reduce timeScale when critically low FPS, update SimulationState.performanceStats, display warning overlay. Depends on T019, T020, T035. (~200 LOC)
+- [x] T037 Performance management system in `src/systems/performanceManager.ts`: monitor FPS (rolling average), activate quality scaling below 30 fps (disable shadows, reduce particles, adjust draw distance), reduce timeScale when critically low FPS, update SimulationState.performanceStats, display warning overlay. Depends on T019, T020, T035. (~200 LOC)
 
 ---
 

--- a/src/systems/performanceManager.ts
+++ b/src/systems/performanceManager.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+
+import type { PerformanceOverlayState } from '../ecs/simulation/performance';
+import type { SimulationWorld } from '../ecs/world';
+import {
+  getPerformanceOverlayState,
+  getSimulationState,
+  recordFrameMetrics,
+  setAutoScalingEnabled,
+} from '../ecs/world';
+import type { PerformanceStats } from '../types';
+
+export interface FrameSubscriber {
+  (callback: (state: unknown, delta: number) => void): void | (() => void);
+}
+
+export interface UsePerformanceManagerOptions {
+  world: SimulationWorld;
+  /** Optional override for registering frame callbacks (defaults to @react-three/fiber useFrame). */
+  useFrameHook?: FrameSubscriber;
+  /** Minimum delta time to consider when computing FPS to avoid division by zero. */
+  minDelta?: number;
+  /** Maximum delta time to clamp spikes, keeping FPS calculations stable. */
+  maxDelta?: number;
+}
+
+export interface PerformanceManagerHandle {
+  /** Latest performance statistics mirrored from the simulation state. */
+  stats: PerformanceStats;
+  /** Overlay visibility/auto-scaling state. */
+  overlay: PerformanceOverlayState;
+  /** Record a manual FPS sample (used in tests or external integrations). */
+  recordSample: (fps: number) => void;
+  /** Toggle automatic quality scaling. */
+  setAutoScaling: (enabled: boolean) => void;
+}
+
+const DEFAULT_MIN_DELTA = 1 / 240; // 240 fps upper bound
+const DEFAULT_MAX_DELTA = 0.25; // 4 fps lower bound
+
+export function usePerformanceManager({
+  world,
+  useFrameHook,
+  minDelta = DEFAULT_MIN_DELTA,
+  maxDelta = DEFAULT_MAX_DELTA,
+}: UsePerformanceManagerOptions): PerformanceManagerHandle {
+  const statsRef = useRef<PerformanceStats>(getSimulationState(world).performanceStats);
+  const overlayRef = useRef<PerformanceOverlayState>(getPerformanceOverlayState(world));
+
+  const [, forceUpdate] = useReducer((value) => value + 1, 0);
+
+  const clampDelta = useCallback(
+    (delta: number) => {
+      if (!Number.isFinite(delta) || delta <= 0) {
+        return minDelta;
+      }
+      return Math.min(Math.max(delta, minDelta), maxDelta);
+    },
+    [maxDelta, minDelta],
+  );
+
+  const syncFromWorld = useCallback(
+    (fps: number) => {
+      const safeFps = Number.isFinite(fps) && fps >= 0 ? fps : 0;
+      recordFrameMetrics(world, safeFps);
+      statsRef.current = getSimulationState(world).performanceStats;
+      overlayRef.current = getPerformanceOverlayState(world);
+      forceUpdate();
+    },
+    [world],
+  );
+
+  const stepRef = useRef(syncFromWorld);
+  stepRef.current = syncFromWorld;
+
+  const handleFrame = useCallback(
+    (_state: unknown, delta: number) => {
+      const clamped = clampDelta(delta);
+      const fps = clamped > 0 ? 1 / clamped : 0;
+      stepRef.current(fps);
+    },
+    [clampDelta],
+  );
+
+  if (!useFrameHook) {
+    useFrame(handleFrame);
+  }
+
+  useEffect(() => {
+    if (!useFrameHook) {
+      return;
+    }
+    const unsubscribe = useFrameHook(handleFrame);
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, [handleFrame, useFrameHook]);
+
+  const recordSample = useCallback(
+    (fps: number) => {
+      stepRef.current(fps);
+    },
+    [],
+  );
+
+  const setAutoScaling = useCallback(
+    (enabled: boolean) => {
+      setAutoScalingEnabled(world, enabled);
+      overlayRef.current = getPerformanceOverlayState(world);
+      forceUpdate();
+    },
+    [world],
+  );
+
+  return {
+    stats: statsRef.current,
+    overlay: overlayRef.current,
+    recordSample,
+    setAutoScaling,
+  };
+}

--- a/src/systems/physicsSync.ts
+++ b/src/systems/physicsSync.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+
+import type { SimulationWorld } from '../ecs/world';
+import { stepSimulation } from '../ecs/world';
+
+export interface FrameSubscription {
+  (callback: (state: unknown, delta: number) => void): void | (() => void);
+}
+
+export interface UsePhysicsSyncOptions {
+  world: SimulationWorld;
+  /** Fixed simulation step in seconds (default: 1/60). */
+  fixedDelta?: number;
+  /** Maximum number of fixed steps to process per frame to avoid spiral of death (default: 5). */
+  maxSubSteps?: number;
+  /** Optional frame hook override for testing (defaults to @react-three/fiber useFrame). */
+  useFrameHook?: FrameSubscription;
+}
+
+export interface PhysicsSyncController {
+  /** Manually advance the simulation by an arbitrary delta time. */
+  step: (deltaTime: number) => void;
+  /** Reset the internal time accumulator. */
+  reset: () => void;
+}
+
+const DEFAULT_FIXED_DELTA = 1 / 60;
+const DEFAULT_MAX_SUB_STEPS = 5;
+
+export function usePhysicsSync({
+  world,
+  fixedDelta = DEFAULT_FIXED_DELTA,
+  maxSubSteps = DEFAULT_MAX_SUB_STEPS,
+  useFrameHook,
+}: UsePhysicsSyncOptions): PhysicsSyncController {
+  const accumulatorRef = useRef(0);
+  const stepRef = useRef<(deltaTime: number) => void>(() => undefined);
+
+  const applyStep = useCallback(
+    (deltaTime: number) => {
+      if (!Number.isFinite(deltaTime) || deltaTime <= 0) {
+        return;
+      }
+
+      accumulatorRef.current += deltaTime;
+      let steps = 0;
+      while (accumulatorRef.current >= fixedDelta && steps < maxSubSteps) {
+        stepSimulation(world, fixedDelta);
+        accumulatorRef.current -= fixedDelta;
+        steps += 1;
+      }
+
+      if (steps === maxSubSteps) {
+        accumulatorRef.current = 0;
+      }
+    },
+    [fixedDelta, maxSubSteps, world],
+  );
+
+  stepRef.current = applyStep;
+
+  if (!useFrameHook) {
+    useFrame((_, delta) => {
+      stepRef.current(delta);
+    });
+  }
+
+  useEffect(() => {
+    if (!useFrameHook) {
+      return;
+    }
+
+    const unsubscribe = useFrameHook((_, delta) => {
+      stepRef.current(delta);
+    });
+
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, [useFrameHook]);
+
+  const reset = useCallback(() => {
+    accumulatorRef.current = 0;
+  }, []);
+
+  return useMemo(
+    () => ({
+      step: applyStep,
+      reset,
+    }),
+    [applyStep, reset],
+  );
+}

--- a/tests/unit/systems/performanceManager.test.ts
+++ b/tests/unit/systems/performanceManager.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { getArenaConfig, initializeSimulation } from '../../../src/ecs/world';
+import { usePerformanceManager } from '../../../src/systems/performanceManager';
+
+describe('usePerformanceManager', () => {
+  it('records frame metrics and enables quality scaling when needed', () => {
+    const world = initializeSimulation();
+
+    const { result } = renderHook(() =>
+      usePerformanceManager({
+        world,
+        useFrameHook: () => undefined,
+      }),
+    );
+
+    expect(result.current.stats.currentFPS).toBeGreaterThanOrEqual(60);
+    expect(result.current.overlay.visible).toBe(false);
+
+    act(() => {
+      result.current.recordSample(25);
+    });
+
+    expect(result.current.stats.qualityScalingActive).toBe(true);
+    expect(result.current.overlay.visible).toBe(true);
+    expect(getArenaConfig(world).lightingConfig.shadowsEnabled).toBe(false);
+    expect(world.simulation.timeScale).toBeLessThan(1);
+
+    act(() => {
+      result.current.recordSample(15);
+    });
+
+    expect(result.current.stats.currentFPS).toBeLessThan(60);
+    expect(result.current.overlay.visible).toBe(true);
+  });
+
+  it('allows disabling auto scaling while keeping stats updated', () => {
+    const world = initializeSimulation();
+
+    const { result } = renderHook(() =>
+      usePerformanceManager({
+        world,
+        useFrameHook: () => undefined,
+      }),
+    );
+
+    act(() => {
+      result.current.setAutoScaling(false);
+      result.current.recordSample(20);
+    });
+
+    expect(result.current.overlay.autoScalingEnabled).toBe(false);
+    expect(result.current.stats.qualityScalingActive).toBe(false);
+    expect(getArenaConfig(world).lightingConfig.shadowsEnabled).toBe(true);
+    expect(world.simulation.timeScale).toBeCloseTo(1, 2);
+  });
+});

--- a/tests/unit/systems/physicsSync.test.ts
+++ b/tests/unit/systems/physicsSync.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { createProjectile } from '../../../src/ecs/entities/Projectile';
+import { initializeSimulation, setPhysicsBodyPosition, getPhysicsSnapshot } from '../../../src/ecs/world';
+import type { SimulationWorld } from '../../../src/ecs/world';
+import type { Vector3 } from '../../../src/types';
+import { usePhysicsSync } from '../../../src/systems/physicsSync';
+
+type FrameCallback = (delta: number) => void;
+
+describe('usePhysicsSync', () => {
+  const createFrameStub = () => {
+    const callbacks: FrameCallback[] = [];
+    const useFrameHook = (cb: (state: unknown, delta: number) => void) => {
+      callbacks.push((delta) => cb({}, delta));
+    };
+    return { callbacks, useFrameHook } as const;
+  };
+
+  it('advances the simulation using a fixed timestep', () => {
+    const world = initializeSimulation();
+    const { callbacks, useFrameHook } = createFrameStub();
+
+    const { result } = renderHook(() =>
+      usePhysicsSync({
+        world,
+        fixedDelta: 1 / 60,
+        maxSubSteps: 5,
+        useFrameHook,
+      }),
+    );
+
+    expect(callbacks).toHaveLength(1);
+    expect(world.simulation.totalFrames).toBe(0);
+
+    act(() => {
+      result.current.step(1 / 30);
+    });
+
+    expect(world.simulation.totalFrames).toBeGreaterThanOrEqual(2);
+
+    act(() => {
+      callbacks[0](1 / 30);
+    });
+
+    expect(world.simulation.totalFrames).toBeGreaterThanOrEqual(4);
+  });
+
+  it('syncs projectile collisions and cleans up removed entities', () => {
+    const world: SimulationWorld = initializeSimulation();
+    const { result } = renderHook(() =>
+      usePhysicsSync({
+        world,
+        fixedDelta: 1 / 120,
+        maxSubSteps: 10,
+        useFrameHook: (cb) => {
+          // no-op stub for registering frames
+          cb({}, 0);
+        },
+      }),
+    );
+
+    const red = world.entities.find((robot) => robot.team === 'red')!;
+    const blue = world.entities.find((robot) => robot.team === 'blue')!;
+
+    const redTarget: Vector3 = { x: -2, y: 0, z: 0 };
+    const blueTarget: Vector3 = { x: 0, y: 0, z: 0 };
+
+    act(() => {
+      setPhysicsBodyPosition(world, red.id, redTarget);
+      setPhysicsBodyPosition(world, blue.id, blueTarget);
+    });
+
+    const projectile = createProjectile({
+      id: 'test-projectile',
+      ownerId: red.id,
+      weaponType: red.weaponType,
+      position: { ...redTarget },
+      velocity: { x: 25, y: 0, z: 0 },
+      damage: blue.maxHealth,
+      distanceTraveled: 0,
+      maxDistance: 20,
+      spawnTime: world.simulation.simulationTime,
+      maxLifetime: 2,
+    });
+
+    world.projectiles.push(projectile);
+
+    act(() => {
+      for (let i = 0; i < 240; i += 1) {
+        result.current.step(1 / 240);
+      }
+    });
+
+    const snapshot = getPhysicsSnapshot(world);
+    expect(world.entities.find((robot) => robot.id === blue.id)).toBeUndefined();
+    expect(snapshot.robots[blue.id]).toBeUndefined();
+    expect(world.projectiles.find((item) => item.id === projectile.id)).toBeUndefined();
+    expect(snapshot.projectiles[projectile.id]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- implement a `usePhysicsSync` system hook that advances the simulation with a fixed timestep and works with custom frame adapters
- add a performance manager hook that records FPS samples, updates quality scaling, and exposes auto-scaling controls
- cover the new hooks with focused unit tests and update the task checklist

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e39fa05d14832aa6a53a3f0b8dd4bc