### PR TITLE
Add Miniplex-backed simulation world context

### DIFF
--- a/specs/001-3d-team-vs/tasks.md
+++ b/specs/001-3d-team-vs/tasks.md
@@ -112,7 +112,7 @@ Single-project structure (per plan.md):
 
 ### ECS Systems (8 tasks - sequential dependencies)
 
-- [ ] T020 Initialize Miniplex ECS world in `src/ecs/world.ts`: create world instance, register entity archetypes, export world singleton and React context provider. Import entity types from T014-T019. (~100 LOC)
+- [x] T020 Initialize Miniplex ECS world in `src/ecs/world.ts`: create world instance, register entity archetypes, export world singleton and React context provider. Import entity types from T014-T019. (~100 LOC)
 
 - [ ] T021 Spawn system in `src/ecs/systems/spawnSystem.ts`: implement robot spawning logic per spawn-contract.md: allocate 10 spawn points per team, create 20 Robot entities with team assignment, balanced weapon distribution, captain election, initialize physics bodies. Use Team and Arena entities. Depends on T014, T017, T018, T020. (~180 LOC)
 

--- a/src/ecs/simulation/aiController.ts
+++ b/src/ecs/simulation/aiController.ts
@@ -164,6 +164,7 @@ export function fireWeapons(world: WorldView): void {
       maxLifetime: 5,
     });
     world.projectiles.push(projectile);
+    world.ecs?.projectiles.add(projectile);
     spawnProjectileBody(world.physics, projectile);
     robot.stats.shotsFired += 1;
     robot.aiState.lastFireTime = now;

--- a/src/ecs/simulation/spawn.ts
+++ b/src/ecs/simulation/spawn.ts
@@ -47,6 +47,7 @@ export function spawnTeam(context: WorldView, team: Team): void {
     });
 
     context.entities.push(robot);
+    context.ecs?.robots.add(robot);
     setRobotBodyPosition(context.physics, robot, robot.position);
   });
 }

--- a/src/ecs/simulation/teamStats.ts
+++ b/src/ecs/simulation/teamStats.ts
@@ -3,16 +3,26 @@ import type { Team } from '../../types';
 import type { WorldView } from './worldTypes';
 import type { WeaponType } from '../../types';
 
+function setTeam(world: WorldView, team: Team, entity: TeamEntity): void {
+  world.teams[team] = entity;
+  if (world.ecs?.teams) {
+    world.ecs.teams.clear();
+    (Object.values(world.teams) as TeamEntity[]).forEach((teamEntity) => {
+      world.ecs.teams.add(teamEntity);
+    });
+  }
+}
+
 export function refreshTeamStats(world: WorldView, teams: Team[]): void {
   teams.forEach((team) => {
     const robots = world.entities.filter((robot) => robot.team === team);
-    world.teams[team] = updateTeamCounts(world.teams[team], robots.length);
+    setTeam(world, team, updateTeamCounts(world.teams[team], robots.length));
     const healthValues = robots.map((robot) => robot.health);
     const weapons: Record<string, WeaponType> = {};
     robots.forEach((robot) => {
       weapons[robot.id] = robot.weaponType;
     });
-    world.teams[team] = updateTeamStats(world.teams[team], healthValues, weapons);
+    setTeam(world, team, updateTeamStats(world.teams[team], healthValues, weapons));
   });
 }
 

--- a/src/ecs/simulation/worldTypes.ts
+++ b/src/ecs/simulation/worldTypes.ts
@@ -5,6 +5,13 @@ import type { SimulationState } from '../entities/SimulationState';
 import type { TeamEntity } from '../entities/Team';
 import type { PhysicsState } from './physics';
 import type { Team } from '../../types';
+import type { World as MiniplexWorld } from 'miniplex';
+
+export interface ECSCollections {
+  robots: MiniplexWorld<Robot>;
+  projectiles: MiniplexWorld<Projectile>;
+  teams: MiniplexWorld<TeamEntity>;
+}
 
 export interface WorldView {
   arena: ArenaEntity;
@@ -13,4 +20,5 @@ export interface WorldView {
   teams: Record<Team, TeamEntity>;
   simulation: SimulationState;
   physics: PhysicsState;
+  ecs?: ECSCollections;
 }

--- a/tests/unit/ecs/world-initialization.test.tsx
+++ b/tests/unit/ecs/world-initialization.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { initializeSimulation, SimulationWorldProvider, useSimulationWorld } from '../../../src/ecs/world';
+
+describe('Simulation world initialization', () => {
+  it('creates an ECS registry with robot entities', () => {
+    const world = initializeSimulation();
+
+    expect(world.ecs).toBeDefined();
+    expect(world.ecs.robots).toBeDefined();
+    expect(typeof world.ecs.robots.add).toBe('function');
+    expect(world.ecs.robots.entities.length).toBe(world.entities.length);
+  });
+
+  it('exposes the simulation world through context provider', () => {
+    const world = initializeSimulation();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SimulationWorldProvider value={world}>{children}</SimulationWorldProvider>
+    );
+
+    const { result } = renderHook(() => useSimulationWorld(), { wrapper });
+
+    expect(result.current).toBe(world);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Miniplex-backed ECS registry to the simulation world along with a React context provider and hook
- keep spawn, combat, AI, and team stat systems in sync with the ECS registries and add coverage for the integration
- mark task T020 complete in the implementation plan and add a focused unit test for the new world context API

## Testing
- npm test -- --run Tests tests/unit/ecs/world-initialization.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e3d850b04c832aa3cac86e75b52aa1