### PR TITLE
Integrate physics sync into Simulation and add frame step test

### DIFF
--- a/specs/001-3d-team-vs/plan.md
+++ b/specs/001-3d-team-vs/plan.md
@@ -310,61 +310,63 @@ Tests are authored before any UI implementation to satisfy Constitution Principl
 - **T002**: Create `tests/integration/ui/stats-modal.test.ts` validating post-battle metrics (per-robot stats, team aggregates, captain markers) rendering in `StatsModal` (FR-019, FR-020).
 - **T003**: Create `tests/integration/ui/performance-banner.test.ts` verifying the quality-scaling warning overlay toggles when `performanceStats.qualityScalingActive` flips and that dismiss/auto-hide logic works (FR-021–FR-023).
 - **T004**: Author unit tests `tests/unit/store/uiStore.test.ts` & `tests/unit/selectors/uiSelectors.test.ts` covering store actions (open/close modals, toggle HUD) and derived data (team counts, captain display, countdown formatting).
+- **T005**: Author integration test `tests/integration/simulation/physics-step.test.tsx` mounting `Simulation` with a stub frame hook to confirm `stepSimulation` runs every frame (FR-012, Constitution Principle IV).
 
-**Gate 1 – Data & State Preparation**  
+**Gate 1 – Data & State Preparation**
 Build the data plumbing that UI components will consume:
-- **T005**: Implement `src/store/uiStore.ts` with Zustand slices for HUD visibility, modal state, countdown overrides, and performance banner flags (≤200 LOC).
-- **T006**: Implement `src/selectors/uiSelectors.ts` to convert ECS queries into memoized view models (team tallies, captain info, performance KPIs) (≤220 LOC).
-- **T007**: Implement `src/hooks/useBattleHudData.ts` consuming selectors and store to provide a typed HUD DTO (status text, team summaries, controls state).
-- **T008**: Implement `src/hooks/usePostBattleStats.ts` assembling the dataset required by `StatsModal`, including per-robot rows sorted by kills/damage.
+- **T006**: Implement `src/store/uiStore.ts` with Zustand slices for HUD visibility, modal state, countdown overrides, and performance banner flags (≤200 LOC).
+- **T007**: Implement `src/selectors/uiSelectors.ts` to convert ECS queries into memoized view models (team tallies, captain info, performance KPIs) (≤220 LOC).
+- **T008**: Implement `src/hooks/useBattleHudData.ts` consuming selectors and store to provide a typed HUD DTO (status text, team summaries, controls state).
+- **T009**: Implement `src/hooks/usePostBattleStats.ts` assembling the dataset required by `StatsModal`, including per-robot rows sorted by kills/damage.
 
-**Gate 2 – HUD Composition**  
+**Gate 2 – HUD Composition**
 Render the always-on HUD shell once data hooks exist:
-- **T009**: Build `src/components/hud/HudRoot.tsx` to compose the HUD layout, wiring `role="banner"` landmarks and responsive positioning (≤180 LOC).
-- **T010**: Build `src/components/hud/TeamStatusPanel.tsx` for each team’s counts, captain badge, weapon distribution chips, and alive/eliminated display (≤160 LOC).
-- **T011**: Build `src/components/hud/BattleTimer.tsx` showing elapsed time and, when active, the victory countdown overlaying the timer (≤120 LOC).
-- **T012**: Build `src/components/hud/ControlStrip.tsx` exposing pause/resume, cinematic toggle, overlay toggle, and settings button (dispatches store actions) (≤200 LOC).
+- **T010**: Build `src/components/hud/HudRoot.tsx` to compose the HUD layout, wiring `role="banner"` landmarks and responsive positioning (≤180 LOC).
+- **T011**: Build `src/components/hud/TeamStatusPanel.tsx` for each team’s counts, captain badge, weapon distribution chips, and alive/eliminated display (≤160 LOC).
+- **T012**: Build `src/components/hud/BattleTimer.tsx` showing elapsed time and, when active, the victory countdown overlaying the timer (≤120 LOC).
+- **T013**: Build `src/components/hud/ControlStrip.tsx` exposing pause/resume, cinematic toggle, overlay toggle, and settings button (dispatches store actions) (≤200 LOC).
 
-**Gate 3 – Overlays & Modals**  
+**Gate 3 – Overlays & Modals**
 Implement the pop-up flows triggered by battle events:
-- **T013**: Build `src/components/overlays/VictoryOverlay.tsx` with countdown, winner messaging, Stats + Settings buttons, and manual restart control (FR-006, FR-014).
-- **T014**: Build `src/components/overlays/StatsModal.tsx` with focus trap, sortable tables, and summary cards sourced from `usePostBattleStats` (FR-019).
-- **T015**: Build `src/components/overlays/SettingsDrawer.tsx` allowing team composition tweaks (weapon distribution sliders, save/apply actions), persisting choices to UI store (FR-006).
-- **T016**: Build `src/components/overlays/PerformanceBanner.tsx` showing FPS, scaling state, dismiss control, and auto-hide animation (FR-021–FR-023).
+- **T014**: Build `src/components/overlays/VictoryOverlay.tsx` with countdown, winner messaging, Stats + Settings buttons, and manual restart control (FR-006, FR-014).
+- **T015**: Build `src/components/overlays/StatsModal.tsx` with focus trap, sortable tables, and summary cards sourced from `usePostBattleStats` (FR-019).
+- **T016**: Build `src/components/overlays/SettingsDrawer.tsx` allowing team composition tweaks (weapon distribution sliders, save/apply actions), persisting choices to UI store (FR-006).
+- **T017**: Build `src/components/overlays/PerformanceBanner.tsx` showing FPS, scaling state, dismiss control, and auto-hide animation (FR-021–FR-023).
 
-**Gate 4 – Interaction & Integration**  
+**Gate 4 – Interaction & Integration**
 Connect UI to runtime state and inputs:
-- **T017**: Implement `src/hooks/useVictoryCountdown.ts` to bridge `SimulationState`, manage the 5-second countdown, and dispatch restart/reset intents (FR-006, FR-014).
-- **T018**: Implement `src/hooks/useUiShortcuts.ts` handling keyboard/gamepad bindings (Space pause, C cinematic, O overlay toggle, Esc close modals) with cleanup (FR-013, FR-006).
-- **T019**: Implement `src/systems/uiBridgeSystem.ts` (Miniplex system) to observe simulation/performance stats each frame and update the UI store without coupling render components to ECS (≤200 LOC).
-- **T020**: Integrate HUD + overlays into `src/App.tsx`, wire store providers, ensure victory & stats systems trigger store actions, and update `quickstart.md` instructions to reference new controls.
+- **T018**: Wire `src/components/Simulation.tsx` to invoke `usePhysicsSync`, supporting optional frame hook injection for deterministic testing and ensuring simulation advances independently of rendering (FR-012).
+- **T019**: Implement `src/hooks/useVictoryCountdown.ts` to bridge `SimulationState`, manage the 5-second countdown, and dispatch restart/reset intents (FR-006, FR-014).
+- **T020**: Implement `src/hooks/useUiShortcuts.ts` handling keyboard/gamepad bindings (Space pause, C cinematic, O overlay toggle, Esc close modals) with cleanup (FR-013, FR-006).
+- **T021**: Implement `src/systems/uiBridgeSystem.ts` (Miniplex system) to observe simulation/performance stats each frame and update the UI store without coupling render components to ECS (≤200 LOC).
+- **T022**: Integrate HUD + overlays into `src/App.tsx`, wire store providers, ensure victory & stats systems trigger store actions, and update `quickstart.md` instructions to reference new controls.
 
 **Gate 5 – Styling & Accessibility**
-- **T021**: Author `src/styles/hud.css` and `src/styles/overlays.css`, ensuring responsive layout, accessible contrast, motion preferences, and captain indicators (≤200 LOC combined).
+- **T023**: Author `src/styles/hud.css` and `src/styles/overlays.css`, ensuring responsive layout, accessible contrast, motion preferences, and captain indicators (≤200 LOC combined).
 
 **Gate 6 – End-to-End Verification**
-- **T022**: Add Playwright scenario `playwright/tests/ui-flow.spec.ts` covering battle completion → victory overlay → stats modal → settings adjustment → restart loop (FR-006, FR-019, FR-014).
+- **T024**: Add Playwright scenario `playwright/tests/ui-flow.spec.ts` covering battle completion → victory overlay → stats modal → settings adjustment → restart loop (FR-006, FR-019, FR-014).
 
 **Ordering Strategy**:
-- Gate 0 tasks (T001–T004) run first and must fail until later gates deliver implementations.
-- Gate 1 (T005–T008) establishes data plumbing; components may not begin until selectors/hooks exist.
-- Gate 2 (T009–T012) can run in parallel per component once data hooks compile.
-- Gate 3 (T013–T016) depends on Gate 1 hooks; T014 waits for `usePostBattleStats` (T008).
-- Gate 4 (T017–T020) depends on overlay/HUD components existing.
-- Gate 5 (T021) styles rely on component markup.
-- Gate 6 (T022) runs last after UI wiring is stable.
+- Gate 0 tasks (T001–T005) run first and must fail until later gates deliver implementations.
+- Gate 1 (T006–T009) establishes data plumbing; components may not begin until selectors/hooks exist.
+- Gate 2 (T010–T013) can run in parallel per component once data hooks compile.
+- Gate 3 (T014–T017) depends on Gate 1 hooks; T015 waits for `usePostBattleStats` (T009).
+- Gate 4 (T018–T022) depends on overlay/HUD components existing and physics sync wiring ready.
+- Gate 5 (T023) styles rely on component markup.
+- Gate 6 (T024) runs last after UI wiring is stable.
 
 **Dependencies**:
 ```
-Tests (T001-T004) → Data & Hooks (T005-T008) → HUD (T009-T012) → Overlays (T013-T016) → Integration (T017-T020) → Styling (T021) → E2E (T022)
+Tests (T001-T005) → Data & Hooks (T006-T009) → HUD (T010-T013) → Overlays (T014-T017) → Integration (T018-T022) → Styling (T023) → E2E (T024)
 
-TDD Gate: T001-T004 MUST fail before T005+ begins.
+TDD Gate: T001-T005 MUST fail before T006+ begins.
 ```
 
 **Parallelization Examples**:
-- After T008, T009–T012 (HUD components) can be developed concurrently (distinct files).
-- After T016, T017 and T018 can progress in parallel (independent hooks) before converging at T019.
-- Styling (T021) can overlap with T020 once component markup is stable.
+- After T009, T010–T013 (HUD components) can be developed concurrently (distinct files).
+- After T017, T019 and T020 can progress in parallel (independent hooks) before converging at T021/T022.
+- Styling (T023) can overlap with T022 once component markup is stable.
 
 **Constitutional Compliance**:
 - Every task references a concrete path under `src/` or `tests/`.
@@ -377,7 +379,7 @@ TDD Gate: T001-T004 MUST fail before T005+ begins.
 Ensure the existing scaffold (`src/main.tsx`, `src/App.tsx`, `src/index.css`, minimal Canvas scene) remains in place so new UI tests can mount the app. Before running the new UI integration suites, confirm:
 
 - `npm run dev` renders the Canvas plus HUD root container without runtime errors.
-- `App.tsx` exports a React component with `#status` placeholder (will be replaced during T020).
+- `App.tsx` exports a React component with `#status` placeholder (will be replaced during T022).
 
 Scaffolding is a prerequisite for Gate 0 tests; do not remove or regress it while implementing the new UI flows.
 
@@ -422,15 +424,15 @@ Scaffolding is a prerequisite for Gate 0 tests; do not remove or regress it whil
 - ✅ contracts/scoring-contract.md (weapon balance validation)
 - ✅ contracts/spawn-contract.md (robot spawning validation)
 - ✅ quickstart.md (validation and demonstration guide)
-- ✅ tasks.md (22 UI-centric tasks with Gate-based ordering)
+- ✅ tasks.md (24 UI-centric tasks with Gate-based ordering)
 
 **Next Steps**:
-1. Write the new UI tests (T001-T004) and confirm they fail.
-2. Deliver data plumbing hooks/store (T005-T008).
-3. Build HUD components (T009-T012) observing LOC limits.
-4. Implement overlays and modals (T013-T016) with focus management.
-5. Wire countdown + shortcuts + ECS bridge (T017-T020) then apply styles (T021).
-6. Run Playwright `ui-flow.spec.ts` (T022) and update CONSTITUTION-CHECK before PR.
+1. Write the new UI tests (T001-T005) and confirm they fail.
+2. Deliver data plumbing hooks/store (T006-T009).
+3. Build HUD components (T010-T013) observing LOC limits.
+4. Implement overlays and modals (T014-T017) with focus management.
+5. Wire physics sync, countdown, shortcuts, and ECS bridge (T018-T022) then apply styles (T023).
+6. Run Playwright `ui-flow.spec.ts` (T024) and update CONSTITUTION-CHECK before PR.
 
 ---
 *Based on Constitution v2.1.1 - See `/memory/constitution.md`*

--- a/specs/001-3d-team-vs/tasks.md
+++ b/specs/001-3d-team-vs/tasks.md
@@ -26,71 +26,73 @@
 
 ---
 
-## Gate 0: UI Flow Tests (4 tasks)
+## Gate 0: UI Flow Tests (5 tasks)
 *Goal: establish failing tests before implementation (Constitution Principle II — Test-First).*
 
 - [x] T001 Create Vitest integration suite `tests/integration/ui/victory-overlay.test.ts` asserting victory overlay countdown, winner label, Stats button, Settings button, manual restart, and auto-reset after 5s. Targets FR-006 + FR-014. Use Testing Library + msw mocks for store actions.
 - [x] T002 Create Vitest integration suite `tests/integration/ui/stats-modal.test.ts` validating Stats modal renders team aggregates, robot rows (kills, damage dealt/taken, time alive), captain indicators, and sorting controls. Covers FR-019 + FR-020.
 - [x] T003 Create Vitest integration suite `tests/integration/ui/performance-banner.test.ts` verifying quality-scaling banner appears when `performanceStats.qualityScalingActive` flips true, displays FPS and scaling state, supports dismiss + auto-hide, and hides when FPS recovers. Covers FR-021 – FR-023.
 - [x] T004 Create unit tests `tests/unit/store/uiStore.test.ts` & `tests/unit/selectors/uiSelectors.test.ts` covering Zustand actions (open/close stats/settings, toggle HUD, set countdown) and selector outputs (team counts, captain info, countdown formatting). Ensures deterministic data layer before UI renders.
+- [ ] T005 Author integration test `tests/integration/simulation/physics-step.test.tsx` mounting `Simulation` within `SimulationWorldProvider` with a stub frame hook, asserting `stepSimulation` runs each frame tick. Satisfies FR-012 and enforces Constitution Principle IV (simulation separate from render).
 
 ## Gate 1: Data & Hooks (4 tasks)
 *Goal: build deterministic data plumbing consumed by HUD and overlays.*
 
-- [x] T005 Implement `src/store/uiStore.ts` (≤200 LOC) defining Zustand slices for HUD visibility, modal state, countdown overrides, performance banner flags, and persisted team composition draft. Include action creators and selectors exported for tests (FR-006, FR-014, FR-021).
-- [x] T006 Implement `src/selectors/uiSelectors.ts` (≤220 LOC) mapping Miniplex queries to typed view models (team tallies, captain badge info, weapon distribution, performance KPIs). Memoize selectors; expose helpers used across hooks and tests (FR-019, FR-020, FR-021).
-- [x] T007 Implement `src/hooks/useBattleHudData.ts` to combine ECS selectors + uiStore state into a HUD DTO (status text, team summaries, control states). Use `useSyncExternalStore` or Zustand hook to subscribe for React correctness. Supports FR-006, FR-013.
-- [x] T008 Implement `src/hooks/usePostBattleStats.ts` aggregating per-robot and per-team metrics from `SimulationState` snapshots, sorting by kills → damage, formatting durations, and exposing summary totals for Stats modal (FR-019).
+- [x] T006 Implement `src/store/uiStore.ts` (≤200 LOC) defining Zustand slices for HUD visibility, modal state, countdown overrides, performance banner flags, and persisted team composition draft. Include action creators and selectors exported for tests (FR-006, FR-014, FR-021).
+- [x] T007 Implement `src/selectors/uiSelectors.ts` (≤220 LOC) mapping Miniplex queries to typed view models (team tallies, captain badge info, weapon distribution, performance KPIs). Memoize selectors; expose helpers used across hooks and tests (FR-019, FR-020, FR-021).
+- [x] T008 Implement `src/hooks/useBattleHudData.ts` to combine ECS selectors + uiStore state into a HUD DTO (status text, team summaries, control states). Use `useSyncExternalStore` or Zustand hook to subscribe for React correctness. Supports FR-006, FR-013.
+- [x] T009 Implement `src/hooks/usePostBattleStats.ts` aggregating per-robot and per-team metrics from `SimulationState` snapshots, sorting by kills → damage, formatting durations, and exposing summary totals for Stats modal (FR-019).
 
 ## Gate 2: HUD Composition (4 tasks)
 *Goal: render persistent HUD surfaces once data hooks exist.*
 
-- [x] T009 Implement `src/components/hud/HudRoot.tsx` (≤180 LOC) that positions HUD via CSS grid, renders match title/status, composes `TeamStatusPanel`, `BattleTimer`, and `ControlStrip`, and exposes an overlay toggle region. Include `role="banner"` and `aria-live="polite"` for status text (FR-006).
-- [x] T010 Implement `src/components/hud/TeamStatusPanel.tsx` for each team, showing alive/eliminated counts, captain marker, weapon distribution chips, and team color accent. Read data from `useBattleHudData`. Covers FR-001, FR-020.
-- [x] T011 Implement `src/components/hud/BattleTimer.tsx` showing elapsed battle time and, when victory pending, the countdown overlay badge. Provide semantic labels for screen readers. Supports FR-006, FR-014.
-- [x] T012 Implement `src/components/hud/ControlStrip.tsx` with buttons for Pause/Resume, Cinematic toggle, HUD toggle, and Settings. Dispatch uiStore actions, respect keyboard focus outlines, and disable controls when overlays/modal already active. Covers FR-006, FR-013.
+- [x] T010 Implement `src/components/hud/HudRoot.tsx` (≤180 LOC) that positions HUD via CSS grid, renders match title/status, composes `TeamStatusPanel`, `BattleTimer`, and `ControlStrip`, and exposes an overlay toggle region. Include `role="banner"` and `aria-live="polite"` for status text (FR-006).
+- [x] T011 Implement `src/components/hud/TeamStatusPanel.tsx` for each team, showing alive/eliminated counts, captain marker, weapon distribution chips, and team color accent. Read data from `useBattleHudData`. Covers FR-001, FR-020.
+- [x] T012 Implement `src/components/hud/BattleTimer.tsx` showing elapsed battle time and, when victory pending, the countdown overlay badge. Provide semantic labels for screen readers. Supports FR-006, FR-014.
+- [x] T013 Implement `src/components/hud/ControlStrip.tsx` with buttons for Pause/Resume, Cinematic toggle, HUD toggle, and Settings. Dispatch uiStore actions, respect keyboard focus outlines, and disable controls when overlays/modal already active. Covers FR-006, FR-013.
 
 ## Gate 3: Overlays & Modals (4 tasks)
 *Goal: deliver pop-up experiences triggered by battle outcomes & performance state.*
 
-- [x] T013 Implement `src/components/overlays/VictoryOverlay.tsx` (≤200 LOC) showing winner, countdown timer, Stats & Settings buttons, manual restart control, and team summary chips. Connect to uiStore + `useVictoryCountdown`. Fulfill FR-006 + FR-014.
-- [x] T014 Implement `src/components/overlays/StatsModal.tsx` with focus trap, keyboard navigation, table sorting, and responsive layout. Consume `usePostBattleStats`, display per-robot rows, team totals, and captain highlight. Satisfies FR-019 + FR-020.
-- [x] T015 Implement `src/components/overlays/SettingsDrawer.tsx` sliding drawer that exposes team composition controls (weapon sliders/toggles), apply/cancel, and resets. Persist values through uiStore for next battle spawn. Aligns with FR-006.
-- [x] T016 Implement `src/components/overlays/PerformanceBanner.tsx` to show FPS, quality-scaling state, auto-hide progress, and dismiss button. Support `aria-live` announcements and user toggle. Covers FR-021 – FR-023.
+- [x] T014 Implement `src/components/overlays/VictoryOverlay.tsx` (≤200 LOC) showing winner, countdown timer, Stats & Settings buttons, manual restart control, and team summary chips. Connect to uiStore + `useVictoryCountdown`. Fulfill FR-006 + FR-014.
+- [x] T015 Implement `src/components/overlays/StatsModal.tsx` with focus trap, keyboard navigation, table sorting, and responsive layout. Consume `usePostBattleStats`, display per-robot rows, team totals, and captain highlight. Satisfies FR-019 + FR-020.
+- [x] T016 Implement `src/components/overlays/SettingsDrawer.tsx` sliding drawer that exposes team composition controls (weapon sliders/toggles), apply/cancel, and resets. Persist values through uiStore for next battle spawn. Aligns with FR-006.
+- [x] T017 Implement `src/components/overlays/PerformanceBanner.tsx` to show FPS, quality-scaling state, auto-hide progress, and dismiss button. Support `aria-live` announcements and user toggle. Covers FR-021 – FR-023.
 
-## Gate 4: Interaction & Integration (4 tasks)
+## Gate 4: Interaction & Integration (5 tasks)
 *Goal: wire runtime events and input handling into the UI.*
 
-- [x] T017 Implement `src/hooks/useVictoryCountdown.ts` handling `SimulationState.status` transitions, starting/stopping the 5s countdown, dispatching auto-restart, and exposing `remainingSeconds`. Integrate with `victorySystem` reset pathway (FR-006, FR-014).
-- [x] T018 Implement `src/hooks/useUiShortcuts.ts` binding keyboard/gamepad events (Space pause, C cinematic, O HUD, Esc close modals) with cleanup, optional touch handling for mobile, and testable command mapping. Supports FR-013, FR-006.
-- [x] T019 Implement `src/systems/uiBridgeSystem.ts` (≤200 LOC Miniplex system) syncing ECS state to uiStore: update team counts, performance metrics, and Stats snapshots when battles end. Keep rendering components pure per Constitution Principle IV. Covers FR-006, FR-019, FR-021.
-- [x] T020 Update `src/App.tsx` to mount `HudRoot`, overlays, providers, and hook initializers (`useBattleHudData`, `useUiShortcuts`, `useVictoryCountdown`). Update `/specs/001-3d-team-vs/quickstart.md` to document new controls and overlays. Ensure no direct ECS mutations from components.
+- [ ] T018 Wire `src/components/Simulation.tsx` to call `usePhysicsSync`, supporting optional frame hook injection for testing so the ECS steps independently of rendering work. Aligns with FR-012 and Constitution Principle IV.
+- [x] T019 Implement `src/hooks/useVictoryCountdown.ts` handling `SimulationState.status` transitions, starting/stopping the 5s countdown, dispatching auto-restart, and exposing `remainingSeconds`. Integrate with `victorySystem` reset pathway (FR-006, FR-014).
+- [x] T020 Implement `src/hooks/useUiShortcuts.ts` binding keyboard/gamepad events (Space pause, C cinematic, O HUD, Esc close modals) with cleanup, optional touch handling for mobile, and testable command mapping. Supports FR-013, FR-006.
+- [x] T021 Implement `src/systems/uiBridgeSystem.ts` (≤200 LOC Miniplex system) syncing ECS state to uiStore: update team counts, performance metrics, and Stats snapshots when battles end. Keep rendering components pure per Constitution Principle IV. Covers FR-006, FR-019, FR-021.
+- [x] T022 Update `src/App.tsx` to mount `HudRoot`, overlays, providers, and hook initializers (`useBattleHudData`, `useUiShortcuts`, `useVictoryCountdown`). Update `/specs/001-3d-team-vs/quickstart.md` to document new controls and overlays. Ensure no direct ECS mutations from components.
 
 ## Gate 5: Styling & Accessibility (1 task)
 *Goal: unify look & feel, ensure responsive + accessible presentation.*
 
-- [x] T021 Create `src/styles/hud.css` and `src/styles/overlays.css` defining layout, typography, color tokens, focus states, prefers-reduced-motion handling, and mobile breakpoints. Wire styles into `App.tsx`. Verify contrast ratios meet WCAG AA.
+- [x] T023 Create `src/styles/hud.css` and `src/styles/overlays.css` defining layout, typography, color tokens, focus states, prefers-reduced-motion handling, and mobile breakpoints. Wire styles into `App.tsx`. Verify contrast ratios meet WCAG AA.
 
 ## Gate 6: End-to-End Validation (1 task)
 *Goal: prove the complete player flow via browser automation.*
 
-- [x] T022 Author Playwright spec `playwright/tests/ui-flow.spec.ts` covering: battle completion triggers Victory overlay → open Stats modal and verify captain/metrics → open Settings, tweak composition, apply → wait for restart and confirm HUD resets. Run in headed + CI modes. Covers FR-006, FR-019, FR-014.
+- [x] T024 Author Playwright spec `playwright/tests/ui-flow.spec.ts` covering: battle completion triggers Victory overlay → open Stats modal and verify captain/metrics → open Settings, tweak composition, apply → wait for restart and confirm HUD resets. Run in headed + CI modes. Covers FR-006, FR-019, FR-014.
 
 ---
 
 ## Dependencies
 ```
-T001-T004 → T005-T008 → T009-T012 → T013-T016 → T017-T020 → T021 → T022
+T001-T005 → T006-T009 → T010-T013 → T014-T017 → T018-T022 → T023 → T024
 ```
 - Gate 2 tasks require hooks from Gate 1 to compile.
-- Gate 3 tasks require Stats hook (T008) and HUD data (T007).
-- Gate 4 tasks depend on overlays/HUD markup.
-- Styling (T021) needs markup finalized; Playwright (T022) runs last.
+- Gate 3 tasks require Stats hook (T009) and HUD data (T008).
+- Gate 4 tasks depend on overlays/HUD markup and the physics sync wiring (T018).
+- Styling (T023) needs markup finalized; Playwright (T024) runs last.
 
 ## Parallel Execution Tips
-- After T008, split HUD tasks: T009 & T010 can progress in parallel while T011 & T012 start once shared utilities ready.
-- After T016, hooks T017/T018 may proceed concurrently before merging into T019/T020.
-- CSS work (T021) can overlap with late integration as long as markup solidified and snapshot tests updated.
+- After T009, split HUD tasks: T010 & T011 can progress in parallel while T012 & T013 start once shared utilities ready.
+- After T017, hooks T019/T020 may proceed concurrently before merging into T021/T022.
+- CSS work (T023) can overlap with late integration as long as markup solidified and snapshot tests updated.
 
 ## Validation Checklist
 - [ ] Gate 0 tests authored and intentionally failing before implementation.
@@ -104,5 +106,5 @@ T001-T004 → T005-T008 → T009-T012 → T013-T016 → T017-T020 → T021 → T
 
 ---
 
-**Total Tasks**: 22  
+**Total Tasks**: 24
 **Status**: ☐ In progress — implementing overlays and integration tasks.

--- a/src/components/Simulation.tsx
+++ b/src/components/Simulation.tsx
@@ -1,18 +1,19 @@
-import { useFrame } from '@react-three/fiber'
 import React from 'react'
 
 import { useSimulationWorld } from '../ecs/world'
+import type { FrameSubscription } from '../systems/physicsSync'
+import { usePhysicsSync } from '../systems/physicsSync'
 import RobotPlaceholder from './RobotPlaceholder'
 
-export default function Simulation() {
+type SimulationProps = {
+  /** Optional override for frame subscription (testing). */
+  useFrameHook?: FrameSubscription
+}
+
+export default function Simulation({ useFrameHook }: SimulationProps) {
   const world = useSimulationWorld()
 
-  // Minimal frame hook to ensure useFrame is exercised. Real simulation
-  // will be handled by ECS stepSimulation.
-  useFrame(() => {
-    // no-op for now
-    void world
-  })
+  usePhysicsSync({ world, useFrameHook })
 
   return (
     <>

--- a/tests/integration/simulation/physics-step.test.tsx
+++ b/tests/integration/simulation/physics-step.test.tsx
@@ -1,0 +1,41 @@
+import { act, render } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import Simulation from '../../../src/components/Simulation'
+import {
+  SimulationWorldProvider,
+  initializeSimulation,
+} from '../../../src/ecs/world'
+import * as worldModule from '../../../src/ecs/world'
+import type { FrameSubscription } from '../../../src/systems/physicsSync'
+
+describe('Simulation physics stepping integration', () => {
+  it('invokes stepSimulation for each rendered frame', () => {
+    const world = initializeSimulation()
+    const frameCallbacks: Array<(delta: number) => void> = []
+    const useFrameHook: FrameSubscription = (callback) => {
+      frameCallbacks.push((delta) => callback({}, delta))
+    }
+
+    const stepSpy = vi.spyOn(worldModule, 'stepSimulation')
+
+    render(
+      <SimulationWorldProvider value={world}>
+        <Simulation useFrameHook={useFrameHook} />
+      </SimulationWorldProvider>,
+    )
+
+    expect(frameCallbacks).toHaveLength(1)
+    expect(stepSpy).not.toHaveBeenCalled()
+
+    act(() => {
+      frameCallbacks[0](1 / 60)
+    })
+
+    expect(stepSpy).toHaveBeenCalledTimes(1)
+    expect(stepSpy).toHaveBeenCalledWith(world, expect.any(Number))
+
+    stepSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- update the feature plan and task list to add explicit physics-sync wiring and integration test coverage for FR-012
- connect the Simulation component to usePhysicsSync with an injectable frame hook to drive the simulation each render frame
- add a Vitest integration test that mounts Simulation with a stub frame hook and verifies stepSimulation is invoked per frame

## Testing
- npm run test -- tests/integration/simulation/physics-step.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4ef628000832a86219d32dd09a9fb