### PR TITLE
Revamp HUD layout with draggable team panel

### DIFF
--- a/src/components/hud/ControlStrip.tsx
+++ b/src/components/hud/ControlStrip.tsx
@@ -59,11 +59,11 @@ export function ControlStrip({
   return (
     <div className="control-strip" role="toolbar" aria-label="Battle controls">
       <div className="control-strip__metrics" aria-live="polite">
-        <span className="control-strip__fps" data-testid="fps-readout">
+        <span className="control-strip__metric control-strip__metric--fps" data-testid="fps-readout">
           {Math.round(performance.fps)} fps
         </span>
         {performance.qualityScalingActive ? (
-          <span className="control-strip__scaling" role="status">
+          <span className="control-strip__metric control-strip__metric--scaling" role="status">
             Performance scaling active
           </span>
         ) : null}
@@ -72,6 +72,7 @@ export function ControlStrip({
       <div className="control-strip__actions">
         <button
           type="button"
+          className="control-strip__button control-strip__button--pause"
           onClick={handlePauseClick}
           disabled={overlaysActive}
         >
@@ -80,18 +81,24 @@ export function ControlStrip({
 
         <button
           type="button"
+          className="control-strip__button control-strip__button--cinematic"
           onClick={handleCinematicClick}
           disabled={overlaysActive}
         >
           {cinematicLabel}
         </button>
 
-        <button type="button" onClick={controls.toggleHud}>
+        <button
+          type="button"
+          className="control-strip__button control-strip__button--hud"
+          onClick={controls.toggleHud}
+        >
           {hudLabel}
         </button>
 
         <button
           type="button"
+          className="control-strip__button control-strip__button--settings"
           onClick={handleSettingsClick}
           disabled={overlaysActive}
         >

--- a/src/components/hud/HudRoot.tsx
+++ b/src/components/hud/HudRoot.tsx
@@ -1,3 +1,6 @@
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useCallback, useRef, useState } from 'react';
+
 import type { BattleHudData } from '../../hooks/useBattleHudData';
 import useBattleHudData from '../../hooks/useBattleHudData';
 import { BattleTimer } from './BattleTimer';
@@ -32,6 +35,15 @@ export function HudRoot(props: HudRootProps) {
   const hud = useBattleHudData();
   const hudTranslucency = useUiStore((s) => s.hudTranslucency);
   const hudPanelPosition = useUiStore((s) => s.hudPanelPosition);
+  const isStacked = hudPanelPosition === 'stacked';
+  const teamPanelRef = useRef<HTMLDivElement>(null);
+  const dragStateRef = useRef<{
+    pointerId: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+  const [teamPanelPosition, setTeamPanelPosition] = useState<{ left: number; top: number } | null>(null);
+  const [teamPanelDragging, setTeamPanelDragging] = useState(false);
 
   if (!hud.controls.isHudVisible) {
     return renderHiddenState(hud);
@@ -39,22 +51,130 @@ export function HudRoot(props: HudRootProps) {
 
   const rootStyle: Record<string, string | number> = { '--hud-translucency': hudTranslucency };
 
+  const clampPosition = useCallback(
+    (left: number, top: number) => {
+      if (typeof window === 'undefined') {
+        return { left, top };
+      }
+
+      const margin = 16;
+      const panel = teamPanelRef.current;
+      const rect = panel?.getBoundingClientRect();
+      const width = rect?.width ?? panel?.offsetWidth ?? 0;
+      const height = rect?.height ?? panel?.offsetHeight ?? 0;
+      const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+      const maxTop = Math.max(margin, window.innerHeight - height - margin);
+
+      return {
+        left: Math.min(Math.max(margin, left), maxLeft),
+        top: Math.min(Math.max(margin, top), maxTop),
+      };
+    },
+    [],
+  );
+
+  const handleTeamPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (isStacked) {
+        return;
+      }
+
+      const panel = teamPanelRef.current;
+      if (!panel) {
+        return;
+      }
+
+      panel.setPointerCapture(event.pointerId);
+      const rect = panel.getBoundingClientRect();
+      dragStateRef.current = {
+        pointerId: event.pointerId,
+        offsetX: event.clientX - rect.left,
+        offsetY: event.clientY - rect.top,
+      };
+      setTeamPanelPosition(clampPosition(rect.left, rect.top));
+      setTeamPanelDragging(true);
+      event.preventDefault();
+    },
+    [clampPosition, isStacked],
+  );
+
+  const handleTeamPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (isStacked) {
+        return;
+      }
+
+      const dragState = dragStateRef.current;
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+
+      const nextLeft = event.clientX - dragState.offsetX;
+      const nextTop = event.clientY - dragState.offsetY;
+      setTeamPanelPosition(clampPosition(nextLeft, nextTop));
+      event.preventDefault();
+    },
+    [clampPosition, isStacked],
+  );
+
+  const handleTeamPointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const dragState = dragStateRef.current;
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+
+      dragStateRef.current = null;
+      setTeamPanelDragging(false);
+      setTeamPanelPosition((prev) => {
+        if (!prev || isStacked) {
+          return prev;
+        }
+
+        return clampPosition(prev.left, prev.top);
+      });
+
+      const panel = teamPanelRef.current;
+      if (panel?.hasPointerCapture(event.pointerId)) {
+        panel.releasePointerCapture(event.pointerId);
+      }
+
+      event.preventDefault();
+    },
+    [clampPosition, isStacked],
+  );
+
+  const teamPanelStyle = isStacked
+    ? undefined
+    : teamPanelPosition
+      ? { top: `${teamPanelPosition.top}px`, left: `${teamPanelPosition.left}px` }
+      : { top: '20px', right: '24px' };
+
+  const teamPanelClassName = [
+    'hud-root__teams',
+    'hud-panel',
+    'hud-panel--teams',
+    teamPanelDragging ? 'hud-root__teams--dragging' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <section
-      className={`hud-root ${hudPanelPosition === 'stacked' ? 'hud-root--stacked' : ''}`}
+      className={`hud-root ${isStacked ? 'hud-root--stacked' : ''}`}
       role="banner"
       aria-live="polite"
       style={rootStyle}
     >
-      {/* Left overlay: Battle Status + timer + controls */}
-      <div className="hud-root__left">
-        <div className="hud-panel hud-panel--status" aria-label="Battle status">
+      {/* Status panel */}
+      <div className="hud-root__status" aria-label="Battle status">
+        <div className="hud-panel hud-panel--status">
           <header className="hud-root__header">
-            <div className="hud-root__header-left">
+            <div className="hud-root__heading">
               <h1 className="hud-root__title">Battle Status</h1>
-              <p className="hud-root__status" data-status={hud.status.status}>
+              <span className="hud-root__status-chip" data-status={hud.status.status}>
                 {hud.status.label}
-              </p>
+              </span>
             </div>
 
             <div className="hud-root__header-right">
@@ -65,7 +185,6 @@ export function HudRoot(props: HudRootProps) {
                 title="Settings"
                 onClick={() => hud.controls.openSettings()}
               >
-                {/* simple gear icon */}
                 <svg
                   width="18"
                   height="18"
@@ -75,7 +194,11 @@ export function HudRoot(props: HudRootProps) {
                   aria-hidden="true"
                 >
                   <path d="M12 15.5A3.5 3.5 0 1 0 12 8.5a3.5 3.5 0 0 0 0 7z" fill="currentColor" />
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06A2 2 0 1 1 2.28 16.88l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09c.7 0 1.3-.41 1.51-1A1.65 1.65 0 0 0 3.28 6.28l-.06-.06A2 2 0 1 1 6.05 2.4l.06.06c.5.5 1.2.69 1.82.33.35-.2.72-.33 1.12-.33H10a2 2 0 1 1 4 0h.09c.4 0 .77.12 1.12.33.62.36 1.32.17 1.82-.33l.06-.06A2 2 0 1 1 21.72 7.12l-.06.06a1.65 1.65 0 0 0-.33 1.82c.2.6.66 1.04 1.29 1.2H21a2 2 0 1 1 0 4h-.09c-.63.16-1.09.6-1.29 1.2z" fill="currentColor" opacity="0.6" />
+                  <path
+                    d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06A2 2 0 1 1 2.28 16.88l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09c.7 0 1.3-.41 1.51-1A1.65 1.65 0 0 0 3.28 6.28l-.06-.06A2 2 0 1 1 6.05 2.4l.06.06c.5.5 1.2.69 1.82.33.35-.2.72-.33 1.12-.33H10a2 2 0 1 1 4 0h.09c.4 0 .77.12 1.12.33.62.36 1.32.17 1.82-.33l.06-.06A2 2 0 1 1 21.72 7.12l-.06.06a1.65 1.65 0 0 0-.33 1.82c.2.6.66 1.04 1.29 1.2H21a2 2 0 1 1 0 4h-.09c-.63.16-1.09.6-1.29 1.2z"
+                    fill="currentColor"
+                    opacity="0.72"
+                  />
                 </svg>
               </button>
             </div>
@@ -83,8 +206,11 @@ export function HudRoot(props: HudRootProps) {
 
           <BattleTimer status={hud.status} />
         </div>
+      </div>
 
-        <div className="hud-panel hud-panel--controls" aria-label="Battle controls">
+      {/* Control menu */}
+      <div className="hud-root__controls" aria-label="Battle controls">
+        <div className="hud-panel hud-panel--controls">
           <ControlStrip
             status={hud.status}
             controls={hud.controls}
@@ -96,9 +222,22 @@ export function HudRoot(props: HudRootProps) {
         </div>
       </div>
 
-      {/* Right overlay: Teams */}
-      <div className="hud-root__right" aria-label="Team status">
-        <div className="hud-panel hud-panel--teams">
+      {/* Team overview */}
+      <div
+        ref={teamPanelRef}
+        className={teamPanelClassName}
+        aria-label="Team status"
+        style={teamPanelStyle}
+        onPointerDown={handleTeamPointerDown}
+        onPointerMove={handleTeamPointerMove}
+        onPointerUp={handleTeamPointerEnd}
+        onPointerCancel={handleTeamPointerEnd}
+      >
+        <div className="hud-teams__header">
+          <h2 className="hud-teams__title">Team Overview</h2>
+          {!isStacked ? <span className="hud-teams__hint">Drag to reposition</span> : null}
+        </div>
+        <div className="hud-teams__list">
           {hud.teams.map((team) => (
             <TeamStatusPanel key={team.teamId} team={team} />
           ))}

--- a/src/components/hud/TeamStatusPanel.tsx
+++ b/src/components/hud/TeamStatusPanel.tsx
@@ -21,7 +21,7 @@ export function TeamStatusPanel({ team }: TeamStatusPanelProps) {
       aria-label={`${team.label} status`}
     >
       <header className="team-status-panel__header">
-        <h2 className="team-status-panel__name">{team.label}</h2>
+        <h3 className="team-status-panel__name">{team.label}</h3>
         {team.captain ? (
           <span className="team-status-panel__captain" role="status">
             Captain: {formatCaptainLabel(team)}
@@ -34,13 +34,13 @@ export function TeamStatusPanel({ team }: TeamStatusPanelProps) {
       </header>
 
       <dl className="team-status-panel__stats">
-        <div>
-          <dt>Alive</dt>
-          <dd>{team.alive}</dd>
+        <div className="team-status-panel__stat">
+          <dt className="team-status-panel__stat-label">Alive</dt>
+          <dd className="team-status-panel__stat-value">{team.alive}</dd>
         </div>
-        <div>
-          <dt>Eliminated</dt>
-          <dd>{team.eliminated}</dd>
+        <div className="team-status-panel__stat">
+          <dt className="team-status-panel__stat-label">Eliminated</dt>
+          <dd className="team-status-panel__stat-value">{team.eliminated}</dd>
         </div>
       </dl>
 
@@ -53,7 +53,7 @@ export function TeamStatusPanel({ team }: TeamStatusPanelProps) {
           <span
             key={weapon}
             role="listitem"
-            className="team-status-panel__weapon"
+            className="team-status-panel__weapon-chip"
           >
             {weapon}: {count}
           </span>

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -50,7 +50,7 @@ const DEFAULT_STATE: UiState = {
   performanceOverlayVisible: true,
   performanceBannerDismissed: false,
   countdownOverrideSeconds: null,
-  hudTranslucency: 0.72,
+  hudTranslucency: 0.5,
   hudPanelPosition: 'left-right',
 };
 

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -2,95 +2,426 @@
 .hud-root {
   position: absolute;
   inset: 0;
-  pointer-events: none; /* allow clicks through except on children */
+  pointer-events: none;
+  color: #f5f7ff;
+  font-family: 'Inter', Arial, sans-serif;
 }
-.hud-root * { pointer-events: auto; }
 
-/* Left column: Battle status and controls at top-left */
-.hud-root__left {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+.hud-root * {
+  pointer-events: auto;
 }
 
 .hud-panel {
-  /* use CSS variable --hud-translucency set on root */
-  background: rgba(10, 14, 20, var(--hud-translucency, 0.72)); /* translucent dark */
-  color: #e6eef8;
-  border: 1px solid rgba(255,255,255,0.04);
-  padding: 10px 12px;
-  border-radius: 6px;
-  box-shadow: 0 6px 18px rgba(0,0,0,0.6);
-  -webkit-backdrop-filter: blur(6px);
-  backdrop-filter: blur(6px);
-  max-width: 420px;
-}
-
-.hud-panel--status .hud-root__header { display: flex; gap: 10px; align-items: baseline; }
-.hud-root__title { font-size: 20px; margin: 0; }
-.hud-root__status { margin: 0; opacity: 0.95; }
-
-.hud-root__header { display: flex; align-items: center; justify-content: space-between; }
-.hud-root__header-left { display: flex; gap: 10px; align-items: baseline; }
-.hud-root__header-right { display: flex; align-items: center; }
-.hud-root__settings-button {
-  background: transparent;
-  border: none;
+  background: rgba(16, 22, 48, var(--hud-translucency, 0.5));
+  border: 1px solid rgba(110, 156, 255, 0.28);
+  border-radius: 16px;
+  padding: 16px 20px;
+  box-shadow: 0 18px 40px rgba(8, 12, 32, 0.45);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  backdrop-filter: blur(14px) saturate(140%);
   color: inherit;
-  padding: 6px;
-  border-radius: 4px;
-  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
 }
-.hud-root__settings-button:hover { background: rgba(255,255,255,0.03); }
-.hud-root__settings-button:focus { outline: 2px solid rgba(255,255,255,0.12); }
 
-/* Controls panel sits to the right of status visually but grouped under left overlay */
-.hud-panel--controls { display: flex; align-items: center; }
-.control-strip { display: flex; gap: 8px; align-items: center; }
-.control-strip__actions button { min-width: 64px; }
-
-/* Right column: team panels grouped at top-right */
-.hud-root__right {
+.hud-root__status,
+.hud-root__controls {
   position: absolute;
-  top: 12px;
-  right: 12px;
-}
-.hud-panel--teams { display: flex; gap: 8px; flex-direction: column; max-width: 320px; }
-.hud-panel--teams { padding: 8px; }
-.team-status-panel { background: transparent; padding: 8px 10px; border-radius: 4px; margin-bottom: 6px; }
-
-/* Make the right panel a distinct container with panel background */
-.hud-root__right > .hud-panel--teams {
-  background: rgba(10,14,20,var(--hud-translucency,0.72));
-  border-radius: 6px;
-  padding: 10px;
-  box-shadow: 0 6px 18px rgba(0,0,0,0.6);
 }
 
-.hud-panel { transition: background-color 160ms ease, transform 160ms ease; }
+.hud-root__status {
+  top: 20px;
+  left: 24px;
+  max-width: 360px;
+}
 
-/* keep left panel width constrained so right panel sits next to it */
-.hud-root__left .hud-panel--status { max-width: 420px; }
-.hud-root__left .hud-panel--controls { max-width: 420px; }
+.hud-root__controls {
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 420px;
+}
 
-/* Responsive: stacked layout for small screens or when user prefers stacked */
-@media (max-width: 640px) {
-  .hud-root__left { left: 8px; top: 8px; }
-  .hud-root__right { right: 8px; top: 72px; }
-  .hud-root--stacked .hud-root__left,
-  .hud-root--stacked .hud-root__right {
-    position: static;
-    width: auto;
+.hud-panel--status {
+  display: grid;
+  gap: 16px;
+}
+
+.hud-root__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hud-root__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hud-root__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.hud-root__status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(123, 163, 255, 0.45), rgba(130, 243, 255, 0.35));
+  color: #f8fbff;
+  box-shadow: inset 0 0 0 1px rgba(166, 205, 255, 0.5);
+}
+
+.hud-root__status-chip[data-status='paused'] {
+  background: linear-gradient(135deg, rgba(255, 196, 110, 0.6), rgba(255, 128, 91, 0.45));
+  box-shadow: inset 0 0 0 1px rgba(255, 161, 91, 0.6);
+}
+
+.hud-root__status-chip[data-status='victory'] {
+  background: linear-gradient(135deg, rgba(127, 255, 194, 0.6), rgba(91, 199, 255, 0.5));
+  box-shadow: inset 0 0 0 1px rgba(140, 255, 214, 0.6);
+}
+
+.hud-root__header-right {
+  display: flex;
+  align-items: center;
+}
+
+.hud-root__settings-button {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(166, 205, 255, 0.35);
+  border-radius: 12px;
+  padding: 6px;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.hud-root__settings-button:hover {
+  background: rgba(166, 205, 255, 0.12);
+  box-shadow: 0 8px 16px rgba(80, 120, 220, 0.25);
+  transform: translateY(-1px);
+}
+
+.hud-root__settings-button:focus-visible {
+  outline: 2px solid rgba(160, 205, 255, 0.9);
+  outline-offset: 2px;
+}
+
+.battle-timer {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.battle-timer__elapsed {
+  padding: 6px 12px;
+  border-radius: 10px;
+  background: rgba(140, 180, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(140, 180, 255, 0.4);
+}
+
+.battle-timer__countdown {
+  padding: 6px 12px;
+  border-radius: 10px;
+  background: rgba(255, 161, 109, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 161, 109, 0.35);
+}
+
+.battle-timer__countdown[data-paused='true'] {
+  background: rgba(255, 213, 138, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(255, 213, 138, 0.4);
+}
+
+.hud-panel--controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  padding: 18px 24px;
+}
+
+.control-strip {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+}
+
+.control-strip__metrics {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.85;
+}
+
+.control-strip__metric {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.control-strip__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.control-strip__button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
+  background: linear-gradient(135deg, rgba(123, 163, 255, 0.92), rgba(119, 94, 255, 0.92));
+  box-shadow: 0 14px 28px rgba(74, 91, 255, 0.35);
+}
+
+.control-strip__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  filter: grayscale(0.2);
+  box-shadow: none;
+}
+
+.control-strip__button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(74, 91, 255, 0.45);
+}
+
+.control-strip__button:not(:disabled):active {
+  transform: translateY(1px);
+  box-shadow: 0 6px 12px rgba(74, 91, 255, 0.35);
+}
+
+.control-strip__button--cinematic {
+  background: linear-gradient(135deg, rgba(255, 135, 201, 0.95), rgba(148, 110, 255, 0.92));
+  box-shadow: 0 14px 28px rgba(231, 114, 210, 0.35);
+}
+
+.control-strip__button--hud {
+  background: linear-gradient(135deg, rgba(84, 220, 255, 0.92), rgba(98, 156, 255, 0.92));
+  box-shadow: 0 14px 28px rgba(76, 196, 255, 0.35);
+  color: #0e1a3b;
+  font-weight: 700;
+}
+
+.control-strip__button--settings {
+  background: linear-gradient(135deg, rgba(255, 193, 117, 0.92), rgba(255, 147, 101, 0.92));
+  box-shadow: 0 14px 28px rgba(255, 170, 102, 0.35);
+  color: #341a05;
+}
+
+.hud-root__teams {
+  position: absolute;
+  top: 20px;
+  right: 24px;
+  max-width: 340px;
+  cursor: grab;
+}
+
+.hud-root__teams--dragging {
+  cursor: grabbing;
+  user-select: none;
+}
+
+.hud-teams__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.hud-teams__title {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hud-teams__hint {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.hud-teams__list {
+  display: grid;
+  gap: 12px;
+}
+
+.team-status-panel {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 14px;
+  padding: 14px 16px;
+  display: grid;
+  gap: 12px;
+  border: 1px solid transparent;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.team-status-panel:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(18, 24, 64, 0.35);
+}
+
+.team-status-panel[data-team='red'] {
+  background: linear-gradient(135deg, rgba(255, 105, 120, 0.28), rgba(255, 154, 90, 0.16));
+  border-color: rgba(255, 128, 128, 0.38);
+  box-shadow: inset 0 0 0 1px rgba(255, 140, 140, 0.4);
+}
+
+.team-status-panel[data-team='blue'] {
+  background: linear-gradient(135deg, rgba(98, 160, 255, 0.26), rgba(116, 246, 255, 0.18));
+  border-color: rgba(118, 196, 255, 0.38);
+  box-shadow: inset 0 0 0 1px rgba(118, 196, 255, 0.4);
+}
+
+.team-status-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.team-status-panel__name {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.team-status-panel__captain {
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.team-status-panel__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.team-status-panel__stat {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(8, 14, 32, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.team-status-panel__stat-label {
+  margin: 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  opacity: 0.7;
+}
+
+.team-status-panel__stat-value {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.team-status-panel__weapons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.team-status-panel__weapon-chip {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.hud-root--stacked {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+
+.hud-root--stacked .hud-panel {
+  width: min(92vw, 640px);
+  margin: 0 auto;
+}
+
+.hud-root--stacked .hud-root__status,
+.hud-root--stacked .hud-root__controls,
+.hud-root--stacked .hud-root__teams {
+  position: static;
+  transform: none;
+  width: 100%;
+  max-width: none;
+}
+
+.hud-root--stacked .hud-root__teams {
+  cursor: grab;
+}
+
+@media (max-width: 720px) {
+  .hud-root__controls {
+    min-width: auto;
+    width: calc(100% - 32px);
   }
-  .hud-root--stacked .hud-panel--teams {
-    margin-top: 8px;
-    display: block;
+
+  .control-strip__actions {
+    gap: 8px;
   }
-  .hud-root { display: flex; flex-direction: column; gap: 8px; padding: 8px; }
+
+  .control-strip__button {
+    padding: 10px 16px;
+  }
+
+  .hud-root__teams {
+    max-width: calc(100% - 32px);
+  }
 }
-.team-status-panel { background: transparent; padding: 6px 8px; border-radius: 4px; }
-.team-status-panel__header { display: block; }
-.team-status-panel__name { margin: 0 0 6px 0; font-size: 18px; }
+
+@media (max-width: 520px) {
+  .hud-root__status {
+    max-width: calc(100% - 32px);
+  }
+
+  .battle-timer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .control-strip__metrics {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- split the HUD into a dedicated status panel, centered control bar, and draggable team overview
- refresh the team status presentation with color-coded chips and a glassmorphism-inspired theme update
- lower the default translucency to 0.5 and restyle control buttons for a more vibrant look

## Testing
- npm run test -- tests/unit/components/hud/TeamStatusPanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e525b9ca58832ab55c2d21c14c14d4