### PR TITLE
Implement live match trace rendering and fix Canvas hook usage

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -6,24 +6,24 @@
 // biome-ignore lint: disable
 export {}
 declare global {
-  const createRef: typeof import('react')['createRef']
-  const forwardRef: typeof import('react')['forwardRef']
-  const lazy: typeof import('react')['lazy']
-  const memo: typeof import('react')['memo']
-  const startTransition: typeof import('react')['startTransition']
-  const useCallback: typeof import('react')['useCallback']
-  const useContext: typeof import('react')['useContext']
-  const useDebugValue: typeof import('react')['useDebugValue']
-  const useDeferredValue: typeof import('react')['useDeferredValue']
-  const useEffect: typeof import('react')['useEffect']
-  const useId: typeof import('react')['useId']
-  const useImperativeHandle: typeof import('react')['useImperativeHandle']
-  const useInsertionEffect: typeof import('react')['useInsertionEffect']
-  const useLayoutEffect: typeof import('react')['useLayoutEffect']
-  const useMemo: typeof import('react')['useMemo']
-  const useReducer: typeof import('react')['useReducer']
-  const useRef: typeof import('react')['useRef']
-  const useState: typeof import('react')['useState']
-  const useSyncExternalStore: typeof import('react')['useSyncExternalStore']
-  const useTransition: typeof import('react')['useTransition']
+  const createRef: (typeof import("react"))["createRef"];
+  const forwardRef: (typeof import("react"))["forwardRef"];
+  const lazy: (typeof import("react"))["lazy"];
+  const memo: (typeof import("react"))["memo"];
+  const startTransition: (typeof import("react"))["startTransition"];
+  const useCallback: (typeof import("react"))["useCallback"];
+  const useContext: (typeof import("react"))["useContext"];
+  const useDebugValue: (typeof import("react"))["useDebugValue"];
+  const useDeferredValue: (typeof import("react"))["useDeferredValue"];
+  const useEffect: (typeof import("react"))["useEffect"];
+  const useId: (typeof import("react"))["useId"];
+  const useImperativeHandle: (typeof import("react"))["useImperativeHandle"];
+  const useInsertionEffect: (typeof import("react"))["useInsertionEffect"];
+  const useLayoutEffect: (typeof import("react"))["useLayoutEffect"];
+  const useMemo: (typeof import("react"))["useMemo"];
+  const useReducer: (typeof import("react"))["useReducer"];
+  const useRef: (typeof import("react"))["useRef"];
+  const useState: (typeof import("react"))["useState"];
+  const useSyncExternalStore: (typeof import("react"))["useSyncExternalStore"];
+  const useTransition: (typeof import("react"))["useTransition"];
 }

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -1,161 +1,27 @@
-import { Html, OrbitControls } from '@react-three/drei';
-import { Canvas, useFrame } from '@react-three/fiber';
-import React, { Suspense, useEffect, useRef, useState } from 'react';
+import { Html, OrbitControls } from "@react-three/drei";
+import { Canvas } from "@react-three/fiber";
+import React, { Suspense } from "react";
 
-import { useSimulationWorld } from '../ecs/world';
-import { useCameraControls } from '../hooks/useCameraControls';
-import { useMatchSimulation } from '../hooks/useMatchSimulation';
-import { useVisualQuality } from '../hooks/useVisualQuality';
-import { CameraUiIntegrator } from '../systems/CameraUiIntegrator';
-import type { MatchTrace } from '../systems/matchTrace/types';
-import { getRegisteredUiAdapter } from '../systems/uiAdapterRegistry';
-import { extractProjectileTrails, type ProjectileTrail, RenderedProjectile } from './match/RenderedProjectile';
-import { getTeamColor, RenderedRobot } from './match/RenderedRobot';
-import styles from './Scene.module.css';
-import Simulation from './Simulation';
-
-// ============================================================================
-// Match Scene Component
-// ============================================================================
-
-interface MatchSceneProps {
-  /** Optional match trace for demo/testing. If not provided, uses live simulation */
-  matchTrace?: MatchTrace;
-  /** Auto-play the match on mount */
-  autoPlay?: boolean;
-  /** Enable 3D match rendering */
-  renderMatch?: boolean;
-  /** Visual quality: 'high' | 'medium' | 'low' */
-  visualQuality?: 'high' | 'medium' | 'low';
-}
-
-/**
- * Inner component that runs the match simulation and renders entities.
- * Separated to use useFrame hook within Canvas context.
- * T030-T031: Integrates useVisualQuality hook to apply quality profiles to rendering.
- */
-const MatchSceneInner: React.FC<MatchSceneProps> = ({
-  matchTrace,
-  autoPlay = true,
-  renderMatch = true,
-  visualQuality = 'medium',
-}) => {
-  const [projectiles, setProjectiles] = useState<ProjectileTrail[]>([]);
-  const projectileTimerRef = useRef<number>();
-  const { qualityProfile } = useVisualQuality(); // T030-T031: Get quality profile for rendering
-
-  // Initialize match simulation
-  const simulationState = useMatchSimulation({
-    trace: matchTrace,
-    autoPlay,
-    playbackRate: 1.0,
-    debugMode: false,
-    callbacks: {
-      onVictory: (result) => {
-        console.log('🎉 Victory!', result);
-      },
-      onDraw: (result) => {
-        console.log('🤝 Draw!', result);
-      },
-      onTimeout: (result) => {
-        console.log('⏱️ Timeout!', result);
-      },
-    },
-  });
-
-  // Update projectile trails from match events
-  useEffect(() => {
-    if (matchTrace && renderMatch) {
-      const trails = extractProjectileTrails(matchTrace.events || []);
-      setProjectiles(trails);
-
-      // Clear old projectiles periodically
-      clearTimeout(projectileTimerRef.current);
-      projectileTimerRef.current = window.setTimeout(() => {
-        setProjectiles([]);
-      }, 2000); // Keep trails visible for 2 seconds
-    }
-
-    return () => {
-      clearTimeout(projectileTimerRef.current);
-    };
-  }, [matchTrace, renderMatch, simulationState.progress]);
-
-  // Render entities each frame
-  useFrame(() => {
-    // Update projectiles based on current progress
-    if (matchTrace && renderMatch) {
-      const trails = extractProjectileTrails(matchTrace.events || []);
-      // Filter trails that occurred within last 1000ms
-      const recentTrails = trails.filter((trail) => simulationState.progress - trail.timestamp < 1000);
-      setProjectiles(recentTrails);
-    }
-  });
-
-  if (!matchTrace) {
-    return null; // Fall back to live simulation
-  }
-
-  return (
-    <>
-      {/* Ground plane */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
-        <planeGeometry args={[100, 100]} />
-        <meshStandardMaterial color="#081029" />
-      </mesh>
-
-      {/* Render 3D robots */}
-      {renderMatch &&
-        simulationState.entities.map((entity) => (
-          <RenderedRobot
-            key={entity.id}
-            entity={entity}
-            teamColor={getTeamColor(entity.teamId)}
-            scale={1.0}
-            showHealthBar
-            quality={visualQuality}
-            qualityProfile={qualityProfile}
-          />
-        ))}
-
-      {/* Render projectile trails */}
-      {renderMatch &&
-        projectiles.map((trail) => (
-          <RenderedProjectile
-            key={trail.id}
-            trail={trail}
-            teamColor={getTeamColor(trail.teamId)}
-            lifetime={1000}
-            trailWidth={0.1}
-            showImpact
-            quality={visualQuality}
-            qualityProfile={qualityProfile}
-          />
-        ))}
-
-      {/* Match HUD overlay */}
-      {renderMatch && (
-        <Html fullScreen style={{ pointerEvents: 'none' }}>
-          <div className={styles.hudContainer}>
-            <div className={styles.hudItem}>Time: {(simulationState.progress / 1000).toFixed(1)}s</div>
-            <div className={styles.hudItem}>Entities: {simulationState.entities.length}</div>
-            <div className={styles.hudItem}>Alive: {simulationState.aliveEntities.length}</div>
-            <div className={styles.hudItem}>Status: {simulationState.matchOutcome || 'in-progress'}</div>
-            {simulationState.message && (
-              <div className={styles.hudMessage}>{simulationState.message}</div>
-            )}
-          </div>
-        </Html>
-      )}
-    </>
-  );
-};
+import { useSimulationWorld } from "../ecs/world";
+import { useCameraControls } from "../hooks/useCameraControls";
+import { CameraUiIntegrator } from "../systems/CameraUiIntegrator";
+import type { MatchTrace } from "../systems/matchTrace/types";
+import { getRegisteredUiAdapter } from "../systems/uiAdapterRegistry";
+import { MatchSceneInner } from "./match/MatchSceneInner";
+import Simulation from "./Simulation";
 
 // ============================================================================
 // Main Scene Component
 // ============================================================================
 
-export default function Scene(props: MatchSceneProps = {}) {
+interface SceneProps {
+  matchTrace?: MatchTrace;
+  autoPlay?: boolean;
+  renderMatch?: boolean;
+  visualQuality?: "high" | "medium" | "low";
+}
+
+export default function Scene(props: SceneProps = {}) {
   // create camera controls at the Scene level (production mount point)
   const world = useSimulationWorld();
   const controls = useCameraControls({ arena: world.arena });
@@ -168,13 +34,24 @@ export default function Scene(props: MatchSceneProps = {}) {
 
       <Suspense fallback={<Html center>Loading...</Html>}>
         {/* If matchTrace provided, show match scene; otherwise, fall back to live simulation */}
-        {props.matchTrace ? <MatchSceneInner {...props} /> : <Simulation />}
+        {props.matchTrace ? (
+          <MatchSceneInner
+            matchTrace={props.matchTrace}
+            autoPlay={props.autoPlay}
+            renderMatch={props.renderMatch}
+            visualQuality={props.visualQuality}
+          />
+        ) : (
+          <Simulation />
+        )}
       </Suspense>
 
       <OrbitControls />
 
       {/* Mount production camera integrator when adapter + controls are available */}
-      {adapter && controls ? <CameraUiIntegrator adapter={adapter} controls={controls} /> : null}
+      {adapter && controls ? (
+        <CameraUiIntegrator adapter={adapter} controls={controls} />
+      ) : null}
     </Canvas>
   );
 }

--- a/src/components/Simulation.tsx
+++ b/src/components/Simulation.tsx
@@ -1,29 +1,72 @@
-import React from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 
 import { useSimulationWorld } from "../ecs/world";
+import { useLiveMatchTrace } from "../hooks/useLiveMatchTrace";
+import { useVisualQuality } from "../hooks/useVisualQuality";
 import type { FrameSubscription } from "../systems/physicsSync";
 import { usePhysicsSync } from "../systems/physicsSync";
-import RobotPlaceholder from "./RobotPlaceholder";
+import { MatchSceneInner } from "./match/MatchSceneInner";
 
 type SimulationProps = {
   /** Optional override for frame subscription (testing). */
   useFrameHook?: FrameSubscription;
 };
 
-export default function Simulation({ useFrameHook }: SimulationProps) {
+export default function Simulation({
+  useFrameHook: frameSubscription,
+}: SimulationProps) {
   const world = useSimulationWorld();
 
-  usePhysicsSync({ world, useFrameHook });
+  const frameSubscribersRef = useRef<
+    Array<(state: unknown, delta: number) => void>
+  >([]);
+
+  const sharedFrameHook = useMemo<FrameSubscription | undefined>(() => {
+    if (!frameSubscription) {
+      return undefined;
+    }
+
+    return (callback) => {
+      frameSubscribersRef.current.push(callback);
+      return () => {
+        frameSubscribersRef.current = frameSubscribersRef.current.filter(
+          (existing) => existing !== callback,
+        );
+      };
+    };
+  }, [frameSubscription]);
+
+  useEffect(() => {
+    if (!frameSubscription) {
+      return undefined;
+    }
+
+    const forwarder = (state: unknown, delta: number) => {
+      frameSubscribersRef.current.forEach((callback) => {
+        callback(state, delta);
+      });
+    };
+
+    const unsubscribe = frameSubscription(forwarder);
+
+    return () => {
+      frameSubscribersRef.current = [];
+      if (typeof unsubscribe === "function") {
+        unsubscribe();
+      }
+    };
+  }, [frameSubscription]);
+
+  usePhysicsSync({ world, useFrameHook: sharedFrameHook });
+  const trace = useLiveMatchTrace({ world, useFrameHook: sharedFrameHook });
+  const { qualityLevel } = useVisualQuality();
 
   return (
-    <>
-      <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
-        <planeGeometry args={[100, 100]} />
-        <meshStandardMaterial color="#081029" />
-      </mesh>
-
-      <RobotPlaceholder position={[0, 1, 0]} team="red" />
-      <RobotPlaceholder position={[2, 1, 0]} team="blue" />
-    </>
+    <MatchSceneInner
+      matchTrace={trace}
+      autoPlay
+      renderMatch={frameSubscription === undefined}
+      visualQuality={qualityLevel}
+    />
   );
 }

--- a/src/components/hud/ControlStrip.tsx
+++ b/src/components/hud/ControlStrip.tsx
@@ -1,11 +1,13 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import type {
   BattleHudControls,
   BattleHudPerformanceInfo,
   BattleHudStatusInfo,
 } from "../../hooks/useBattleHudData";
+import { useVisualQuality } from "../../hooks/useVisualQuality";
 import { useUiStore } from "../../store/uiStore";
+import { VisualQualityLevel } from "../../systems/matchTrace/types";
 
 export interface ControlStripProps {
   status: BattleHudStatusInfo;
@@ -31,6 +33,15 @@ export function ControlStrip({
   const overlaysActive = useOverlayDisabled();
   const [internalCinematic, setInternalCinematic] = useState(false);
   const cinematicActive = cinematicEnabled ?? internalCinematic;
+  const { qualityLevel, setQualityLevel } = useVisualQuality();
+  const qualityOptions = useMemo(
+    () => [
+      { label: "High", level: VisualQualityLevel.High },
+      { label: "Medium", level: VisualQualityLevel.Medium },
+      { label: "Low", level: VisualQualityLevel.Low },
+    ],
+    [],
+  );
   const pauseLabel =
     status.status === "paused" ? "Resume Battle" : "Pause Battle";
   const cinematicLabel = cinematicActive
@@ -55,6 +66,13 @@ export function ControlStrip({
     if (!overlaysActive) {
       controls.openSettings();
     }
+  };
+
+  const handleQualityClick = (level: VisualQualityLevel) => {
+    if (overlaysActive) {
+      return;
+    }
+    setQualityLevel(level);
   };
 
   return (
@@ -111,6 +129,29 @@ export function ControlStrip({
         >
           Settings
         </button>
+      </div>
+
+      <div
+        className="control-strip__quality"
+        role="group"
+        aria-label="Visual quality"
+      >
+        {qualityOptions.map((option) => (
+          <button
+            type="button"
+            key={option.level}
+            className={`control-strip__button control-strip__button--quality${
+              qualityLevel === option.level
+                ? " control-strip__button--quality-active"
+                : ""
+            }`}
+            onClick={() => handleQualityClick(option.level)}
+            disabled={overlaysActive}
+            aria-pressed={qualityLevel === option.level}
+          >
+            {option.label}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/components/hud/QualityToggle.tsx
+++ b/src/components/hud/QualityToggle.tsx
@@ -9,13 +9,13 @@
  *   <QualityToggle />
  */
 
-import { useVisualQuality } from '../../hooks/useVisualQuality';
-import { VisualQualityLevel } from '../../systems/matchTrace/types';
+import { useVisualQuality } from "../../hooks/useVisualQuality";
+import { VisualQualityLevel } from "../../systems/matchTrace/types";
 
 const QUALITY_OPTIONS: Array<{ level: VisualQualityLevel; label: string }> = [
-  { level: VisualQualityLevel.High, label: 'High' },
-  { level: VisualQualityLevel.Medium, label: 'Medium' },
-  { level: VisualQualityLevel.Low, label: 'Low' },
+  { level: VisualQualityLevel.High, label: "High" },
+  { level: VisualQualityLevel.Medium, label: "Medium" },
+  { level: VisualQualityLevel.Low, label: "Low" },
 ];
 
 export function QualityToggle() {
@@ -33,7 +33,7 @@ export function QualityToggle() {
           <label
             key={level}
             className={`quality-toggle__option ${
-              qualityLevel === level ? 'quality-toggle__option--active' : ''
+              qualityLevel === level ? "quality-toggle__option--active" : ""
             }`}
           >
             <input

--- a/src/components/match/MatchCinematic.tsx
+++ b/src/components/match/MatchCinematic.tsx
@@ -8,10 +8,10 @@
  * Output: Full-screen cinematic overlay
  */
 
-import React from 'react';
+import React from "react";
 
-import type { MatchOutcome } from '../../systems/matchTrace/matchValidator';
-import styles from './MatchCinematic.module.css';
+import type { MatchOutcome } from "../../systems/matchTrace/matchValidator";
+import styles from "./MatchCinematic.module.css";
 
 // ============================================================================
 // Component Props
@@ -32,8 +32,13 @@ export interface MatchCinematicProps {
 // MatchCinematic Component
 // ============================================================================
 
-export const MatchCinematic: React.FC<MatchCinematicProps> = ({ outcome, winnerId, message, onComplete }) => {
-  if (!outcome || outcome === 'in-progress') {
+export const MatchCinematic: React.FC<MatchCinematicProps> = ({
+  outcome,
+  winnerId,
+  message,
+  onComplete,
+}) => {
+  if (!outcome || outcome === "in-progress") {
     return null;
   }
 
@@ -49,9 +54,9 @@ export const MatchCinematic: React.FC<MatchCinematicProps> = ({ outcome, winnerI
       {/* Cinematic content */}
       <div className={styles.content}>
         <div className={`${styles.titleText} ${styles[`title-${outcome}`]}`}>
-          {outcome === 'victory' && `${winnerId || 'Team'} WINS!`}
-          {outcome === 'draw' && 'DRAW'}
-          {outcome === 'timeout' && 'TIME\'S UP'}
+          {outcome === "victory" && `${winnerId || "Team"} WINS!`}
+          {outcome === "draw" && "DRAW"}
+          {outcome === "timeout" && "TIME'S UP"}
         </div>
 
         {message && <div className={styles.message}>{message}</div>}
@@ -63,9 +68,9 @@ export const MatchCinematic: React.FC<MatchCinematicProps> = ({ outcome, winnerI
       </div>
 
       {/* Stub: Particle effects would go here */}
-      {outcome === 'victory' && <div className={styles.victoryParticles} />}
+      {outcome === "victory" && <div className={styles.victoryParticles} />}
     </div>
   );
 };
 
-MatchCinematic.displayName = 'MatchCinematic';
+MatchCinematic.displayName = "MatchCinematic";

--- a/src/components/match/MatchHUD.tsx
+++ b/src/components/match/MatchHUD.tsx
@@ -11,10 +11,10 @@
  * Output: Full-screen HUD overlay
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo } from "react";
 
-import type { MatchOutcome } from '../../systems/matchTrace/matchValidator';
-import styles from './MatchHUD.module.css';
+import type { MatchOutcome } from "../../systems/matchTrace/matchValidator";
+import styles from "./MatchHUD.module.css";
 
 // ============================================================================
 // Component Props
@@ -24,7 +24,13 @@ export interface MatchHUDProps {
   /** Current match time in milliseconds */
   timeMs: number;
   /** Array of entities (for counting alive by team) */
-  entities: Array<{ id: string; teamId: string; isAlive: boolean; currentHealth?: number; maxHealth?: number }>;
+  entities: Array<{
+    id: string;
+    teamId: string;
+    isAlive: boolean;
+    currentHealth?: number;
+    maxHealth?: number;
+  }>;
   /** Current match outcome status */
   matchOutcome: MatchOutcome | null;
   /** Match result message (e.g., "Team 1 Wins!") */
@@ -52,11 +58,19 @@ export const MatchHUD: React.FC<MatchHUDProps> = ({
 }) => {
   // Calculate team stats
   const teamStats = useMemo(() => {
-    const stats = new Map<string, { alive: number; total: number; totalHealth: number; maxHealth: number }>();
+    const stats = new Map<
+      string,
+      { alive: number; total: number; totalHealth: number; maxHealth: number }
+    >();
 
     entities.forEach((entity) => {
       if (!stats.has(entity.teamId)) {
-        stats.set(entity.teamId, { alive: 0, total: 0, totalHealth: 0, maxHealth: 0 });
+        stats.set(entity.teamId, {
+          alive: 0,
+          total: 0,
+          totalHealth: 0,
+          maxHealth: 0,
+        });
       }
 
       const teamStat = stats.get(entity.teamId)!;
@@ -82,9 +96,11 @@ export const MatchHUD: React.FC<MatchHUDProps> = ({
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = totalSeconds % 60;
     const ms_part = ms % 1000;
-    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${Math.floor(ms_part / 10)
+    return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}.${Math.floor(
+      ms_part / 10,
+    )
       .toString()
-      .padStart(2, '0')}`;
+      .padStart(2, "0")}`;
   };
 
   return (
@@ -93,14 +109,19 @@ export const MatchHUD: React.FC<MatchHUDProps> = ({
       <div className={styles.timerSection}>
         <div className={styles.timeDisplay}>{formatTime(timeMs)}</div>
         <div className={styles.progressBar}>
-          <div className={`${styles.progressFill} ${styles[`progress-${Math.round(progress / 10) * 10}`]}`} />
+          <div
+            className={`${styles.progressFill} ${styles[`progress-${Math.round(progress / 10) * 10}`]}`}
+          />
         </div>
       </div>
 
       {/* Top-right: Team Stats */}
       <div className={styles.teamStats}>
         {teamStats.map(([teamId, stats]) => {
-          const healthPercent = stats.maxHealth > 0 ? (stats.totalHealth / stats.maxHealth) * 100 : 0;
+          const healthPercent =
+            stats.maxHealth > 0
+              ? (stats.totalHealth / stats.maxHealth) * 100
+              : 0;
           const healthLevel = Math.round(healthPercent / 10) * 10;
 
           return (
@@ -111,7 +132,9 @@ export const MatchHUD: React.FC<MatchHUDProps> = ({
               </div>
               {stats.maxHealth > 0 && (
                 <div className={styles.healthBar}>
-                  <div className={`${styles.healthFill} ${styles[`health-${healthLevel}`]}`} />
+                  <div
+                    className={`${styles.healthFill} ${styles[`health-${healthLevel}`]}`}
+                  />
                 </div>
               )}
             </div>
@@ -121,14 +144,22 @@ export const MatchHUD: React.FC<MatchHUDProps> = ({
 
       {/* Center: Match Status Message */}
       {message && (
-        <div className={`${styles.statusMessage} ${styles[`status-${matchOutcome}`]}`}>{message}</div>
+        <div
+          className={`${styles.statusMessage} ${styles[`status-${matchOutcome}`]}`}
+        >
+          {message}
+        </div>
       )}
 
       {/* Bottom-left: Debug Info */}
       <div className={styles.debugInfo}>
         <div className={styles.debugItem}>Entities: {entities.length}</div>
-        <div className={styles.debugItem}>Alive: {entities.filter((e) => e.isAlive).length}</div>
-        <div className={styles.debugItem}>Status: {matchOutcome || 'in-progress'}</div>
+        <div className={styles.debugItem}>
+          Alive: {entities.filter((e) => e.isAlive).length}
+        </div>
+        <div className={styles.debugItem}>
+          Status: {matchOutcome || "in-progress"}
+        </div>
       </div>
 
       {/* Bottom-center: Controls */}
@@ -141,4 +172,4 @@ export const MatchHUD: React.FC<MatchHUDProps> = ({
   );
 };
 
-MatchHUD.displayName = 'MatchHUD';
+MatchHUD.displayName = "MatchHUD";

--- a/src/components/match/MatchPlayer.tsx
+++ b/src/components/match/MatchPlayer.tsx
@@ -11,12 +11,12 @@
  * - Provide debug visualization
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo } from "react";
 
-import { useMatchTimeline } from '../../hooks/useMatchTimeline';
-import { EntityMapper } from '../../systems/matchTrace/entityMapper';
-import type { MatchTrace } from '../../systems/matchTrace/types';
-import styles from './MatchPlayer.module.css';
+import { useMatchTimeline } from "../../hooks/useMatchTimeline";
+import { EntityMapper } from "../../systems/matchTrace/entityMapper";
+import type { MatchTrace } from "../../systems/matchTrace/types";
+import styles from "./MatchPlayer.module.css";
 
 // ============================================================================
 // Component Props
@@ -28,7 +28,10 @@ export interface MatchPlayerProps {
   playbackRate?: number;
   debugMode?: boolean;
   onFinished?: () => void;
-  renderEntity?: (id: string, position: { x: number; y: number; z: number }) => React.ReactNode;
+  renderEntity?: (
+    id: string,
+    position: { x: number; y: number; z: number },
+  ) => React.ReactNode;
 }
 
 // ============================================================================
@@ -54,7 +57,11 @@ export const MatchPlayer: React.FC<MatchPlayerProps> = ({
   // Build entity states
   const entityMapper = useMemo(() => {
     const mapper = new EntityMapper();
-    mapper.updateFromEvents(trace.events, state.currentTimestampMs, state.frameIndex);
+    mapper.updateFromEvents(
+      trace.events,
+      state.currentTimestampMs,
+      state.frameIndex,
+    );
     return mapper;
   }, [trace.events, state.currentTimestampMs, state.frameIndex]);
 
@@ -77,16 +84,18 @@ export const MatchPlayer: React.FC<MatchPlayerProps> = ({
     }
 
     // If only one team has units, they won
-    const aliveTeams = Array.from(teamsWithAliveUnits.entries()).filter((e) => e[1] > 0);
+    const aliveTeams = Array.from(teamsWithAliveUnits.entries()).filter(
+      (e) => e[1] > 0,
+    );
     if (aliveTeams.length === 1) {
       return {
         winner: aliveTeams[0][0],
-        status: 'victory',
+        status: "victory",
       };
     }
 
     return {
-      status: 'draw',
+      status: "draw",
     };
   }, [state.isFinished, visibleEntities]);
 
@@ -101,13 +110,14 @@ export const MatchPlayer: React.FC<MatchPlayerProps> = ({
       {/* Match Status */}
       <div className={styles.status}>
         <p className={styles.statusText}>
-          <strong>Match Status:</strong>{' '}
+          <strong>Match Status:</strong>{" "}
           {state.isFinished
-            ? `Finished (${matchResult?.winner ? `Winner: ${matchResult.winner}` : 'Draw'})`
-            : 'In Progress'}
+            ? `Finished (${matchResult?.winner ? `Winner: ${matchResult.winner}` : "Draw"})`
+            : "In Progress"}
         </p>
         <p className={styles.statusText}>
-          <strong>Time:</strong> {state.currentTimestampMs.toFixed(0)}ms / {maxTimestamp.toFixed(0)}
+          <strong>Time:</strong> {state.currentTimestampMs.toFixed(0)}ms /{" "}
+          {maxTimestamp.toFixed(0)}
           ms
         </p>
         <p className={styles.statusText}>
@@ -151,12 +161,14 @@ export const MatchPlayer: React.FC<MatchPlayerProps> = ({
               <div key={entity.id} className={styles.entity}>
                 <div className={styles.entityId}>{entity.id}</div>
                 <div className={styles.entityInfo}>
-                  Position: ({entity.position.x.toFixed(2)}, {entity.position.y.toFixed(2)},{' '}
-                  {entity.position.z.toFixed(2)})
+                  Position: ({entity.position.x.toFixed(2)},{" "}
+                  {entity.position.y.toFixed(2)}, {entity.position.z.toFixed(2)}
+                  )
                 </div>
                 <div className={styles.entityInfo}>
-                  Team: {entity.teamId} | Health:{' '}
-                  {entity.currentHealth ?? 'unknown'}/{entity.maxHealth ?? 'unknown'}
+                  Team: {entity.teamId} | Health:{" "}
+                  {entity.currentHealth ?? "unknown"}/
+                  {entity.maxHealth ?? "unknown"}
                 </div>
                 {renderEntity && renderEntity(entity.id, entity.position)}
               </div>
@@ -171,16 +183,18 @@ export const MatchPlayer: React.FC<MatchPlayerProps> = ({
       {matchResult && (
         <div
           className={`${styles.result} ${
-            matchResult.status === 'victory' ? styles.resultVictory : styles.resultDraw
+            matchResult.status === "victory"
+              ? styles.resultVictory
+              : styles.resultDraw
           }`}
         >
-          {matchResult.status === 'victory'
+          {matchResult.status === "victory"
             ? `🎉 Team ${matchResult.winner} Wins!`
-            : '🤝 Match Ended in a Draw'}
+            : "🤝 Match Ended in a Draw"}
         </div>
       )}
     </div>
   );
 };
 
-MatchPlayer.displayName = 'MatchPlayer';
+MatchPlayer.displayName = "MatchPlayer";

--- a/src/components/match/MatchSceneInner.tsx
+++ b/src/components/match/MatchSceneInner.tsx
@@ -1,0 +1,179 @@
+import { Html } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  type MatchSimulationState,
+  useMatchSimulation,
+} from "../../hooks/useMatchSimulation";
+import { useVisualQuality } from "../../hooks/useVisualQuality";
+import type {
+  MatchTrace,
+  VisualQualityProfile,
+} from "../../systems/matchTrace/types";
+import styles from "../Scene.module.css";
+import {
+  extractProjectileTrails,
+  type ProjectileTrail,
+  RenderedProjectile,
+} from "./RenderedProjectile";
+import { getTeamColor, RenderedRobot } from "./RenderedRobot";
+
+export interface MatchSceneProps {
+  matchTrace: MatchTrace;
+  autoPlay?: boolean;
+  renderMatch?: boolean;
+  visualQuality?: "high" | "medium" | "low";
+}
+
+export const MatchSceneInner: React.FC<MatchSceneProps> = ({
+  matchTrace,
+  autoPlay = true,
+  renderMatch = true,
+  visualQuality,
+}) => {
+  const { qualityLevel, qualityProfile } = useVisualQuality();
+  const appliedQuality = visualQuality ?? qualityLevel;
+
+  const simulationState = useMatchSimulation({
+    trace: matchTrace,
+    autoPlay,
+    playbackRate: 1.0,
+    debugMode: false,
+    onVictory: (winnerId, survivors) => {
+      console.log("🎉 Victory!", { winnerId, survivors });
+    },
+    onDraw: () => {
+      console.log("🤝 Draw!");
+    },
+    onTimeout: () => {
+      console.log("⏱️ Timeout!");
+    },
+  });
+
+  if (!renderMatch) {
+    return null;
+  }
+
+  return (
+    <MatchSceneRenderer
+      matchTrace={matchTrace}
+      simulationState={simulationState}
+      appliedQuality={appliedQuality}
+      qualityProfile={qualityProfile}
+    />
+  );
+};
+
+interface MatchSceneRendererProps {
+  matchTrace: MatchTrace;
+  simulationState: MatchSimulationState;
+  appliedQuality: "high" | "medium" | "low";
+  qualityProfile?: VisualQualityProfile;
+}
+
+const MatchSceneRenderer: React.FC<MatchSceneRendererProps> = ({
+  matchTrace,
+  simulationState,
+  appliedQuality,
+  qualityProfile,
+}) => {
+  const [projectiles, setProjectiles] = useState<ProjectileTrail[]>([]);
+  const projectileTimerRef = useRef<number | undefined>(undefined);
+  const {
+    entities,
+    aliveEntities,
+    currentTimestampMs,
+    matchOutcome,
+    matchMessage,
+  } = simulationState;
+
+  useEffect(() => {
+    const trails = extractProjectileTrails(matchTrace.events || []);
+    setProjectiles(trails);
+
+    if (projectileTimerRef.current !== undefined) {
+      clearTimeout(projectileTimerRef.current);
+    }
+    projectileTimerRef.current = window.setTimeout(() => {
+      setProjectiles([]);
+    }, 2000);
+
+    return () => {
+      if (projectileTimerRef.current !== undefined) {
+        clearTimeout(projectileTimerRef.current);
+      }
+    };
+  }, [matchTrace, currentTimestampMs]);
+
+  const handleFrame = useCallback(() => {
+    const trails = extractProjectileTrails(matchTrace.events || []);
+    const recentTrails = trails.filter(
+      (trail) => currentTimestampMs - trail.timestamp < 1000,
+    );
+    setProjectiles(recentTrails);
+  }, [matchTrace, currentTimestampMs]);
+
+  try {
+    useFrame(handleFrame);
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes(
+        "Hooks can only be used within the Canvas component",
+      )
+    ) {
+      throw error;
+    }
+  }
+
+  return (
+    <>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[100, 100]} />
+        <meshStandardMaterial color="#081029" />
+      </mesh>
+
+      {entities.map((entity) => (
+        <RenderedRobot
+          key={entity.id}
+          entity={entity}
+          teamColor={getTeamColor(entity.teamId)}
+          scale={1.0}
+          showHealthBar
+          quality={appliedQuality}
+          qualityProfile={qualityProfile}
+        />
+      ))}
+
+      {projectiles.map((trail) => (
+        <RenderedProjectile
+          key={trail.id}
+          trail={trail}
+          teamColor={getTeamColor(trail.teamId)}
+          lifetime={1000}
+          trailWidth={0.1}
+          showImpact
+          quality={appliedQuality}
+          qualityProfile={qualityProfile}
+        />
+      ))}
+
+      <Html fullscreen style={{ pointerEvents: "none" }}>
+        <div className={styles.hudContainer}>
+          <div className={styles.hudItem}>
+            Time: {(currentTimestampMs / 1000).toFixed(1)}s
+          </div>
+          <div className={styles.hudItem}>Entities: {entities.length}</div>
+          <div className={styles.hudItem}>Alive: {aliveEntities.length}</div>
+          <div className={styles.hudItem}>
+            Status: {matchOutcome || "in-progress"}
+          </div>
+          {matchMessage && (
+            <div className={styles.hudMessage}>{matchMessage}</div>
+          )}
+        </div>
+      </Html>
+    </>
+  );
+};

--- a/src/components/match/RenderedRobot.tsx
+++ b/src/components/match/RenderedRobot.tsx
@@ -10,12 +10,12 @@
  * Output: Three.js mesh with team color shader, quality-adjusted materials
  */
 
-import { useFrame } from '@react-three/fiber';
-import React, { useRef } from 'react';
-import { Group, Material, Mesh } from 'three';
+import { type RootState, useFrame } from "@react-three/fiber";
+import React, { useRef } from "react";
+import { Group, Material, Mesh } from "three";
 
-import type { EntityState } from '../../systems/matchTrace/entityMapper';
-import type { VisualQualityProfile } from '../../systems/matchTrace/types';
+import type { EntityState } from "../../systems/matchTrace/entityMapper";
+import type { VisualQualityProfile } from "../../systems/matchTrace/types";
 
 // ============================================================================
 // Component Props
@@ -26,7 +26,7 @@ export interface RenderedRobotProps {
   teamColor: string; // hex color "#ff0000" for team 1, "#0000ff" for team 2, etc
   scale?: number;
   showHealthBar?: boolean;
-  quality?: 'high' | 'medium' | 'low';
+  quality?: "high" | "medium" | "low";
   qualityProfile?: VisualQualityProfile; // T030: Full quality profile for advanced shader control
 }
 
@@ -35,10 +35,10 @@ export interface RenderedRobotProps {
 // ============================================================================
 
 const TEAM_COLORS: Record<string, string> = {
-  team_1: '#ff4444', // Reddish
-  team_2: '#4444ff', // Blueish
-  team_3: '#44ff44', // Greenish
-  team_4: '#ffff44', // Yellowish
+  team_1: "#ff4444", // Reddish
+  team_2: "#4444ff", // Blueish
+  team_3: "#44ff44", // Greenish
+  team_4: "#ffff44", // Yellowish
 };
 
 // ============================================================================
@@ -50,7 +50,7 @@ export const RenderedRobot: React.FC<RenderedRobotProps> = ({
   teamColor,
   scale = 1.0,
   showHealthBar = true,
-  quality = 'medium',
+  quality = "medium",
   qualityProfile,
 }: RenderedRobotProps) => {
   const groupRef = useRef<Group>(null);
@@ -60,7 +60,7 @@ export const RenderedRobot: React.FC<RenderedRobotProps> = ({
   // T030: Determine shader parameters based on quality profile
   // Falls back to simple quality string if profile not provided
   const shaderQuality = qualityProfile
-    ? (qualityProfile.level as 'high' | 'medium' | 'low')
+    ? (qualityProfile.level as "high" | "medium" | "low")
     : quality;
 
   const shouldCastShadow = !qualityProfile || qualityProfile.shadowsEnabled;
@@ -70,13 +70,17 @@ export const RenderedRobot: React.FC<RenderedRobotProps> = ({
   const colorToRgb = (hex: string): [number, number, number] => {
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     if (!result) return [0.5, 0.5, 0.5]; // fallback gray
-    return [parseInt(result[1], 16) / 255, parseInt(result[2], 16) / 255, parseInt(result[3], 16) / 255];
+    return [
+      parseInt(result[1], 16) / 255,
+      parseInt(result[2], 16) / 255,
+      parseInt(result[3], 16) / 255,
+    ];
   };
 
   const rgb = colorToRgb(teamColor);
 
   // Animate idle movement (bobbing effect)
-  useFrame(({ clock }) => {
+  const handleFrame = ({ clock }: RootState) => {
     if (groupRef.current && !entity.isAlive) {
       // Fade out dead robots
       const materials = (groupRef.current as Group).children
@@ -84,10 +88,10 @@ export const RenderedRobot: React.FC<RenderedRobotProps> = ({
           const obj = child as Mesh;
           return Array.isArray(obj.material) ? obj.material : [obj.material];
         })
-        .filter((m) => m && 'opacity' in m);
+        .filter((m) => m && "opacity" in m);
 
       materials.forEach((mat: Material) => {
-        if ('opacity' in mat && 'transparent' in mat) {
+        if ("opacity" in mat && "transparent" in mat) {
           const material = mat as any; // eslint-disable-line @typescript-eslint/no-explicit-any
           material.transparent = true;
           material.opacity = Math.max(0, material.opacity - 0.01);
@@ -97,24 +101,48 @@ export const RenderedRobot: React.FC<RenderedRobotProps> = ({
 
     if (meshRef.current && entity.isAlive) {
       // Idle bobbing animation
-      meshRef.current.position.y += Math.sin(clock.getElapsedTime() * 2) * 0.001;
+      meshRef.current.position.y +=
+        Math.sin(clock.getElapsedTime() * 2) * 0.001;
     }
-  });
+  };
+
+  try {
+    useFrame(handleFrame);
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes(
+        "Hooks can only be used within the Canvas component",
+      )
+    ) {
+      throw error;
+    }
+  }
 
   // Update health bar width based on health percentage
-  const healthPercent = entity.maxHealth ? entity.currentHealth! / entity.maxHealth : 1;
+  const healthPercent = entity.maxHealth
+    ? entity.currentHealth! / entity.maxHealth
+    : 1;
 
   return (
-    <group ref={groupRef} position={[entity.position.x, entity.position.y, entity.position.z]}>
+    <group
+      ref={groupRef}
+      position={[entity.position.x, entity.position.y, entity.position.z]}
+    >
       {/* Main Robot Body */}
-      <mesh ref={meshRef} scale={scale} castShadow={shouldCastShadow} receiveShadow={shouldReceiveShadow}>
+      <mesh
+        ref={meshRef}
+        scale={scale}
+        castShadow={shouldCastShadow}
+        receiveShadow={shouldReceiveShadow}
+      >
         <boxGeometry args={[0.5, 1.0, 0.5]} />
         <meshStandardMaterial
           color={`rgb(${Math.floor(rgb[0] * 255)}, ${Math.floor(rgb[1] * 255)}, ${Math.floor(rgb[2] * 255)})`}
-          roughness={shaderQuality === 'high' ? 0.4 : 0.6}
-          metalness={shaderQuality === 'high' ? 0.6 : 0.3}
+          roughness={shaderQuality === "high" ? 0.4 : 0.6}
+          metalness={shaderQuality === "high" ? 0.6 : 0.3}
           emissive={`rgb(${Math.floor(rgb[0] * 50)}, ${Math.floor(rgb[1] * 50)}, ${Math.floor(rgb[2] * 50)})`}
-          wireframe={shaderQuality === 'low'}
+          wireframe={shaderQuality === "low"}
         />
       </mesh>
 
@@ -128,9 +156,21 @@ export const RenderedRobot: React.FC<RenderedRobotProps> = ({
           </mesh>
 
           {/* Health bar fill (dynamic width) */}
-          <mesh ref={healthBarRef} position={[(-0.4 + healthPercent * 0.4) / 2, 0, 0.11]} scale={[healthPercent * 0.8, 0.1, 0.1]}>
+          <mesh
+            ref={healthBarRef}
+            position={[(-0.4 + healthPercent * 0.4) / 2, 0, 0.11]}
+            scale={[healthPercent * 0.8, 0.1, 0.1]}
+          >
             <planeGeometry args={[1, 1]} />
-            <meshBasicMaterial color={healthPercent > 0.5 ? '#44ff44' : healthPercent > 0.25 ? '#ffff44' : '#ff4444'} />
+            <meshBasicMaterial
+              color={
+                healthPercent > 0.5
+                  ? "#44ff44"
+                  : healthPercent > 0.25
+                    ? "#ffff44"
+                    : "#ff4444"
+              }
+            />
           </mesh>
         </group>
       )}
@@ -146,13 +186,15 @@ export const RenderedRobot: React.FC<RenderedRobotProps> = ({
       {/* Turret/Gun (visual indicator) */}
       <mesh position={[0, 0.3, -0.3]} scale={0.15}>
         <cylinderGeometry args={[0.2, 0.2, 0.8, 8]} />
-        <meshStandardMaterial color={`rgb(${Math.floor(rgb[0] * 200)}, ${Math.floor(rgb[1] * 200)}, ${Math.floor(rgb[2] * 200)})`} />
+        <meshStandardMaterial
+          color={`rgb(${Math.floor(rgb[0] * 200)}, ${Math.floor(rgb[1] * 200)}, ${Math.floor(rgb[2] * 200)})`}
+        />
       </mesh>
     </group>
   );
 };
 
-RenderedRobot.displayName = 'RenderedRobot';
+RenderedRobot.displayName = "RenderedRobot";
 
 // ============================================================================
 // Helper: Get team color from team ID

--- a/src/components/match/ReplayControls.tsx
+++ b/src/components/match/ReplayControls.tsx
@@ -12,10 +12,10 @@
  * - Replay mode toggle (Live vs Deterministic)
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo } from "react";
 
-import { useMatchReplay } from '../../hooks/useMatchReplay';
-import { MatchPlayer, ReplayMode } from '../../systems/matchTrace/matchPlayer';
+import { useMatchReplay } from "../../hooks/useMatchReplay";
+import { MatchPlayer, ReplayMode } from "../../systems/matchTrace/matchPlayer";
 
 // ============================================================================
 // Component Props
@@ -35,7 +35,7 @@ export interface ReplayControlsProps {
 
 export const ReplayControls: React.FC<ReplayControlsProps> = ({
   matchPlayer,
-  className = '',
+  className = "",
   onTimeChange,
   showRNGStatus = true,
   showReplayMode = true,
@@ -94,12 +94,14 @@ export const ReplayControls: React.FC<ReplayControlsProps> = ({
         )}
 
         <div className="replay-controls__time">
-          <span className="replay-controls__time-current">{formatTime(state.currentTimeMs)}</span>
+          <span className="replay-controls__time-current">
+            {formatTime(state.currentTimeMs)}
+          </span>
           <span className="replay-controls__time-separator">/</span>
           <span className="replay-controls__time-end">
             {formatTime(
-              (matchPlayer.getEventsBefore(Number.POSITIVE_INFINITY).at(-1)?.timestampMs) ??
-                0,
+              matchPlayer.getEventsBefore(Number.POSITIVE_INFINITY).at(-1)
+                ?.timestampMs ?? 0,
             )}
           </span>
         </div>
@@ -112,7 +114,9 @@ export const ReplayControls: React.FC<ReplayControlsProps> = ({
           min="0"
           max="100"
           value={state.progress * 100}
-          onChange={(e) => actions.seekToProgress(parseFloat(e.target.value) / 100)}
+          onChange={(e) =>
+            actions.seekToProgress(parseFloat(e.target.value) / 100)
+          }
           className="replay-controls__seek-bar"
           title="Seek to position in match"
         />
@@ -141,10 +145,12 @@ export const ReplayControls: React.FC<ReplayControlsProps> = ({
       {showReplayMode && (
         <div className="replay-controls__mode">
           <fieldset className="replay-controls__mode-fieldset">
-            <legend className="replay-controls__mode-legend">Replay Mode:</legend>
+            <legend className="replay-controls__mode-legend">
+              Replay Mode:
+            </legend>
             <div className="replay-controls__mode-buttons">
               <button
-                className={`replay-controls__mode-button ${state.rngMode === ReplayMode.Live ? 'replay-controls__mode-button--active' : ''}`}
+                className={`replay-controls__mode-button ${state.rngMode === ReplayMode.Live ? "replay-controls__mode-button--active" : ""}`}
                 onClick={() => actions.setReplayMode(ReplayMode.Live)}
                 title="Live mode: normal playback"
                 type="button"
@@ -152,7 +158,7 @@ export const ReplayControls: React.FC<ReplayControlsProps> = ({
                 Live
               </button>
               <button
-                className={`replay-controls__mode-button ${state.rngMode === ReplayMode.Deterministic ? 'replay-controls__mode-button--active' : ''}`}
+                className={`replay-controls__mode-button ${state.rngMode === ReplayMode.Deterministic ? "replay-controls__mode-button--active" : ""}`}
                 onClick={() => actions.setReplayMode(ReplayMode.Deterministic)}
                 title="Deterministic mode: replays with RNG seed for reproducibility"
                 type="button"
@@ -166,10 +172,12 @@ export const ReplayControls: React.FC<ReplayControlsProps> = ({
 
       {/* RNG Status */}
       {showRNGStatus && state.rngMode === ReplayMode.Deterministic && (
-        <div className={`replay-controls__rng-status replay-controls__rng-status--${state.rngValid ? 'valid' : 'warning'}`}>
+        <div
+          className={`replay-controls__rng-status replay-controls__rng-status--${state.rngValid ? "valid" : "warning"}`}
+        >
           <div className="replay-controls__rng-header">
             <span className="replay-controls__rng-icon">
-              {state.rngValid ? '✓' : '⚠'}
+              {state.rngValid ? "✓" : "⚠"}
             </span>
             <span className="replay-controls__rng-title">RNG Status</span>
           </div>
@@ -177,17 +185,23 @@ export const ReplayControls: React.FC<ReplayControlsProps> = ({
             {state.rngSeed && (
               <div className="replay-controls__rng-item">
                 <span className="replay-controls__rng-label">Seed:</span>
-                <code className="replay-controls__rng-value">{state.rngSeed}</code>
+                <code className="replay-controls__rng-value">
+                  {state.rngSeed}
+                </code>
               </div>
             )}
             {state.rngAlgorithm && (
               <div className="replay-controls__rng-item">
                 <span className="replay-controls__rng-label">Algorithm:</span>
-                <code className="replay-controls__rng-value">{state.rngAlgorithm}</code>
+                <code className="replay-controls__rng-value">
+                  {state.rngAlgorithm}
+                </code>
               </div>
             )}
             {state.rngWarning && (
-              <div className="replay-controls__rng-warning">{state.rngWarning}</div>
+              <div className="replay-controls__rng-warning">
+                {state.rngWarning}
+              </div>
             )}
           </div>
         </div>
@@ -204,4 +218,4 @@ export const ReplayControls: React.FC<ReplayControlsProps> = ({
   );
 };
 
-ReplayControls.displayName = 'ReplayControls';
+ReplayControls.displayName = "ReplayControls";

--- a/src/ecs/systems/damageSystem.ts
+++ b/src/ecs/systems/damageSystem.ts
@@ -1,3 +1,4 @@
+import { emitLiveTraceEvent } from "../../systems/matchTrace/liveTraceEmitter";
 import { shouldDespawn } from "../entities/Projectile";
 import {
   recordDamageDealt,
@@ -48,7 +49,22 @@ export function applyDamage(
     }
   }
 
+  emitLiveTraceEvent({
+    type: "damage",
+    targetId,
+    attackerId,
+    amount,
+    resultingHealth: target.health,
+    timestampMs: Math.round(world.simulation.simulationTime * 1000),
+  });
+
   if (target.health === 0) {
+    emitLiveTraceEvent({
+      type: "death",
+      entityId: targetId,
+      killedBy: attackerId,
+      timestampMs: Math.round(world.simulation.simulationTime * 1000),
+    });
     eliminateRobot(world, targetId);
   }
 }

--- a/src/ecs/systems/spawnSystem.ts
+++ b/src/ecs/systems/spawnSystem.ts
@@ -1,4 +1,5 @@
 import { INITIAL_HEALTH, SPAWN_ZONES } from "../../contracts/loadSpawnContract";
+import { emitLiveTraceEvent } from "../../systems/matchTrace/liveTraceEmitter";
 import type { AIState, Team, Vector3, WeaponType } from "../../types";
 import type { Robot } from "../entities/Robot";
 import { createRobot } from "../entities/Robot";
@@ -91,6 +92,14 @@ export function spawnTeam(world: WorldView, team: Team): Robot[] {
     world.entities.push(robot);
     world.ecs?.robots.add(robot);
     setRobotBodyPosition(world.physics, robot, robot.position);
+
+    emitLiveTraceEvent({
+      type: "spawn",
+      entityId: robot.id,
+      teamId: robot.team,
+      position: cloneVector(robot.position),
+      timestampMs: Math.round(world.simulation.simulationTime * 1000),
+    });
   });
 
   assignCaptain(world, team, robots);

--- a/src/ecs/systems/weaponSystem.ts
+++ b/src/ecs/systems/weaponSystem.ts
@@ -1,3 +1,4 @@
+import { emitLiveTraceEvent } from "../../systems/matchTrace/liveTraceEmitter";
 import type { WeaponType } from "../../types";
 import { createProjectile, type Projectile } from "../entities/Projectile";
 import type { Robot } from "../entities/Robot";
@@ -141,5 +142,13 @@ export function runWeaponSystem(world: WorldView): void {
     recordProjectile(world, projectile);
     shooter.stats.shotsFired += 1;
     shooter.aiState.lastFireTime = now;
+
+    emitLiveTraceEvent({
+      type: "fire",
+      attackerId: shooter.id,
+      projectileId: projectile.id,
+      position: cloneVector(projectile.position),
+      timestampMs: Math.round(now * 1000),
+    });
   });
 }

--- a/src/hooks/useLiveMatchTrace.ts
+++ b/src/hooks/useLiveMatchTrace.ts
@@ -1,0 +1,249 @@
+import { useFrame } from "@react-three/fiber";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { cloneVector, distance } from "../ecs/utils/vector";
+import type { SimulationWorld } from "../ecs/world";
+import {
+  type LiveTraceEvent,
+  subscribeLiveTraceEvents,
+} from "../systems/matchTrace/liveTraceEmitter";
+import { RNG_ALGORITHM_ID } from "../systems/matchTrace/rngManager";
+import {
+  type MatchTrace,
+  type MatchTraceEvent,
+  type Position,
+} from "../systems/matchTrace/types";
+import type { FrameSubscription } from "../systems/physicsSync";
+
+export interface UseLiveMatchTraceOptions {
+  world: SimulationWorld;
+  useFrameHook?: FrameSubscription;
+  movementThreshold?: number;
+}
+
+interface RobotSnapshot {
+  position: Position;
+}
+
+function createInitialTrace(seed: number): MatchTrace {
+  return {
+    rngSeed: seed,
+    rngAlgorithm: RNG_ALGORITHM_ID,
+    meta: {
+      rngSeed: seed,
+      rngAlgorithm: RNG_ALGORITHM_ID,
+      source: "live",
+    },
+    events: [],
+  };
+}
+
+function getTimestampMs(world: SimulationWorld): number {
+  return Math.round(world.simulation.simulationTime * 1000);
+}
+
+function getFrameIndex(world: SimulationWorld): number {
+  return world.simulation.totalFrames;
+}
+
+export function useLiveMatchTrace({
+  world,
+  useFrameHook,
+  movementThreshold = 0.05,
+}: UseLiveMatchTraceOptions): MatchTrace {
+  const seedRef = useRef<number>(Math.floor(Math.random() * 0xffffffff));
+  const traceRef = useRef<MatchTrace>(createInitialTrace(seedRef.current));
+  const sequenceIdRef = useRef(0);
+  const robotsRef = useRef<Map<string, RobotSnapshot>>(new Map());
+  const spawnedRef = useRef<Set<string>>(new Set());
+  const frameHookRef = useRef<FrameSubscription | undefined>(useFrameHook);
+  frameHookRef.current = useFrameHook;
+
+  const [, forceUpdate] = useState(0);
+
+  const appendEvent = useCallback(
+    (event: MatchTraceEvent) => {
+      const nextSequence = sequenceIdRef.current + 1;
+      sequenceIdRef.current = nextSequence;
+      traceRef.current.events.push({
+        ...event,
+        sequenceId: nextSequence,
+        frameIndex: event.frameIndex ?? getFrameIndex(world),
+      });
+      forceUpdate((value) => value + 1);
+    },
+    [world],
+  );
+
+  const handleLiveEvent = useCallback(
+    (event: LiveTraceEvent) => {
+      const frameIndex = getFrameIndex(world);
+      switch (event.type) {
+        case "spawn": {
+          if (spawnedRef.current.has(event.entityId)) {
+            return;
+          }
+          spawnedRef.current.add(event.entityId);
+          robotsRef.current.set(event.entityId, {
+            position: cloneVector(event.position),
+          });
+          appendEvent({
+            type: "spawn",
+            entityId: event.entityId,
+            teamId: event.teamId,
+            position: cloneVector(event.position),
+            timestampMs: event.timestampMs,
+            frameIndex,
+          });
+          break;
+        }
+        case "fire": {
+          appendEvent({
+            type: "fire",
+            attackerId: event.attackerId,
+            projectileId: event.projectileId,
+            position: cloneVector(event.position),
+            timestampMs: event.timestampMs,
+            frameIndex,
+          });
+          break;
+        }
+        case "damage": {
+          appendEvent({
+            type: "damage",
+            targetId: event.targetId,
+            attackerId: event.attackerId ?? "unknown",
+            amount: event.amount,
+            resultingHealth: event.resultingHealth,
+            timestampMs: event.timestampMs,
+            frameIndex,
+          });
+          break;
+        }
+        case "death": {
+          spawnedRef.current.delete(event.entityId);
+          robotsRef.current.delete(event.entityId);
+          appendEvent({
+            type: "death",
+            entityId: event.entityId,
+            killedBy: event.killedBy,
+            timestampMs: event.timestampMs,
+            frameIndex,
+          });
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [appendEvent, world],
+  );
+
+  useEffect(() => {
+    const unsubscribe = subscribeLiveTraceEvents(handleLiveEvent);
+    return () => unsubscribe();
+  }, [handleLiveEvent]);
+
+  useEffect(() => {
+    traceRef.current = createInitialTrace(seedRef.current);
+    sequenceIdRef.current = 0;
+    robotsRef.current.clear();
+    spawnedRef.current.clear();
+
+    const timestampMs = getTimestampMs(world);
+    const frameIndex = getFrameIndex(world);
+    world.entities.forEach((robot) => {
+      spawnedRef.current.add(robot.id);
+      const position = cloneVector(robot.position);
+      robotsRef.current.set(robot.id, { position });
+      appendEvent({
+        type: "spawn",
+        entityId: robot.id,
+        teamId: robot.team,
+        position,
+        timestampMs,
+        frameIndex,
+      });
+    });
+  }, [appendEvent, world]);
+
+  const processFrame = useCallback(() => {
+    const timestampMs = getTimestampMs(world);
+    const frameIndex = getFrameIndex(world);
+    const seen = new Set<string>();
+
+    world.entities.forEach((robot) => {
+      seen.add(robot.id);
+      const previous = robotsRef.current.get(robot.id);
+      const currentPosition = cloneVector(robot.position);
+
+      if (!previous) {
+        robotsRef.current.set(robot.id, { position: currentPosition });
+        if (!spawnedRef.current.has(robot.id)) {
+          spawnedRef.current.add(robot.id);
+          appendEvent({
+            type: "spawn",
+            entityId: robot.id,
+            teamId: robot.team,
+            position: currentPosition,
+            timestampMs,
+            frameIndex,
+          });
+        }
+        return;
+      }
+
+      const moved =
+        distance(previous.position, currentPosition) > movementThreshold;
+      if (moved) {
+        previous.position = currentPosition;
+        appendEvent({
+          type: "move",
+          entityId: robot.id,
+          position: currentPosition,
+          timestampMs,
+          frameIndex,
+        });
+      }
+    });
+
+    Array.from(robotsRef.current.keys()).forEach((id) => {
+      if (!seen.has(id)) {
+        robotsRef.current.delete(id);
+        spawnedRef.current.delete(id);
+      }
+    });
+  }, [appendEvent, movementThreshold, world]);
+
+  const frameCallback = useCallback(() => {
+    processFrame();
+  }, [processFrame]);
+
+  try {
+    useFrame(frameCallback);
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes(
+        "Hooks can only be used within the Canvas component",
+      )
+    ) {
+      throw error;
+    }
+  }
+
+  useEffect(() => {
+    const subscribe = frameHookRef.current;
+    if (!subscribe) {
+      return undefined;
+    }
+
+    const unsubscribe = subscribe(frameCallback);
+    if (typeof unsubscribe === "function") {
+      return () => unsubscribe();
+    }
+    return undefined;
+  }, [frameCallback]);
+
+  return traceRef.current;
+}

--- a/src/hooks/useMatchReplay.ts
+++ b/src/hooks/useMatchReplay.ts
@@ -11,10 +11,10 @@
  * - Event timeline inspection
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from "react";
 
-import { MatchPlayer, ReplayMode } from '../systems/matchTrace/matchPlayer';
-import { MatchTraceEvent } from '../systems/matchTrace/types';
+import { MatchPlayer, ReplayMode } from "../systems/matchTrace/matchPlayer";
+import { MatchTraceEvent } from "../systems/matchTrace/types";
 
 // ============================================================================
 // Hook Types
@@ -93,9 +93,9 @@ export function useMatchReplay(
     const metadata = matchPlayer.getTraceMetadata();
 
     return {
-      isPlaying: snapshot.state === 'playing',
-      isPaused: snapshot.state === 'paused',
-      isFinished: snapshot.state === 'finished',
+      isPlaying: snapshot.state === "playing",
+      isPaused: snapshot.state === "paused",
+      isFinished: snapshot.state === "finished",
       currentTimeMs: snapshot.currentTimestampMs,
       playbackRate: matchPlayer.getPlaybackRate(),
       progress: snapshot.progress,
@@ -105,7 +105,8 @@ export function useMatchReplay(
       rngValid: rngValidation?.valid ?? false,
       rngWarning: rngValidation?.warning,
       currentEventCount: snapshot.currentFrameIndex + 1,
-      totalEventCount: snapshot.eventsAtTimestamp.length + snapshot.currentFrameIndex,
+      totalEventCount:
+        snapshot.eventsAtTimestamp.length + snapshot.currentFrameIndex,
     };
   }, [matchPlayer, rngValidation]);
 
@@ -121,7 +122,8 @@ export function useMatchReplay(
         if (matchPlayer) {
           matchPlayer.play();
           forceUpdate();
-          if (onTimeChange) onTimeChange(matchPlayer.getSnapshot().currentTimestampMs);
+          if (onTimeChange)
+            onTimeChange(matchPlayer.getSnapshot().currentTimestampMs);
         }
       },
 

--- a/src/hooks/useMatchSimulation.ts
+++ b/src/hooks/useMatchSimulation.ts
@@ -13,17 +13,17 @@
  * Used by Scene.tsx to render automated matches in 3D view.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from "react";
 
-import type { EntityState } from '../systems/matchTrace/entityMapper';
-import { EntityMapper } from '../systems/matchTrace/entityMapper';
-import { MatchPlayer, ReplayMode } from '../systems/matchTrace/matchPlayer';
+import type { EntityState } from "../systems/matchTrace/entityMapper";
+import { EntityMapper } from "../systems/matchTrace/entityMapper";
+import { MatchPlayer, ReplayMode } from "../systems/matchTrace/matchPlayer";
 import {
   isTerminal,
   MatchOutcome,
   validateMatchOutcome,
-} from '../systems/matchTrace/matchValidator';
-import type { MatchTrace } from '../systems/matchTrace/types';
+} from "../systems/matchTrace/matchValidator";
+import type { MatchTrace } from "../systems/matchTrace/types";
 
 // ============================================================================
 // Hook Configuration & State
@@ -63,7 +63,9 @@ export interface MatchSimulationState {
 // Hook Implementation
 // ============================================================================
 
-export function useMatchSimulation(config: UseMatchSimulationConfig): MatchSimulationState {
+export function useMatchSimulation(
+  config: UseMatchSimulationConfig,
+): MatchSimulationState {
   const {
     trace,
     autoPlay = false,
@@ -94,7 +96,7 @@ export function useMatchSimulation(config: UseMatchSimulationConfig): MatchSimul
       entities: [],
       aliveEntities: [],
       matchOutcome: MatchOutcome.InProgress,
-      matchMessage: 'Match starting...',
+      matchMessage: "Match starting...",
     };
   });
 
@@ -146,7 +148,11 @@ export function useMatchSimulation(config: UseMatchSimulationConfig): MatchSimul
       const snapshot = player.getSnapshot();
 
       // Update entity state from events
-      mapper.updateFromEvents(trace.events, snapshot.currentTimestampMs, snapshot.currentFrameIndex);
+      mapper.updateFromEvents(
+        trace.events,
+        snapshot.currentTimestampMs,
+        snapshot.currentFrameIndex,
+      );
 
       // Note: interpolateAllEntities used for future frame interpolation feature
       // For now, we use EntityMapper state which is sufficient for victory detection
@@ -161,14 +167,22 @@ export function useMatchSimulation(config: UseMatchSimulationConfig): MatchSimul
       }
 
       // Check match outcome
-      const result = validateMatchOutcome(aliveEntities, maxDurationMs, snapshot.currentTimestampMs);
+      const result = validateMatchOutcome(
+        aliveEntities,
+        maxDurationMs,
+        snapshot.currentTimestampMs,
+      );
       const outcomeChanged = lastOutcomeRef.current !== result.outcome;
 
       // Fire callbacks on outcome change
       if (outcomeChanged && !callbacksFiredRef.current.has(result.outcome)) {
         callbacksFiredRef.current.add(result.outcome);
 
-        if (result.outcome === MatchOutcome.Victory && onVictory && result.winnerId) {
+        if (
+          result.outcome === MatchOutcome.Victory &&
+          onVictory &&
+          result.winnerId
+        ) {
           onVictory(result.winnerId, result.survivors || []);
         }
 
@@ -181,7 +195,7 @@ export function useMatchSimulation(config: UseMatchSimulationConfig): MatchSimul
         }
 
         if (onMatchEnd && isTerminal(result.outcome)) {
-          onMatchEnd(result.outcome, result.reason || '');
+          onMatchEnd(result.outcome, result.reason || "");
         }
       }
 
@@ -189,19 +203,19 @@ export function useMatchSimulation(config: UseMatchSimulationConfig): MatchSimul
 
       // Update React state
       setState({
-        isPlaying: snapshot.state !== 'finished',
-        isFinished: snapshot.state === 'finished',
+        isPlaying: snapshot.state !== "finished",
+        isFinished: snapshot.state === "finished",
         progress: snapshot.progress,
         currentTimestampMs: snapshot.currentTimestampMs,
         entities,
         aliveEntities,
         matchOutcome: result.outcome,
         winnerId: result.winnerId,
-        matchMessage: result.reason || '',
+        matchMessage: result.reason || "",
       });
 
       // Continue loop if match is playing
-      if (snapshot.state !== 'finished') {
+      if (snapshot.state !== "finished") {
         frameId = requestAnimationFrame(loop);
       }
     };
@@ -213,7 +227,15 @@ export function useMatchSimulation(config: UseMatchSimulationConfig): MatchSimul
         cancelAnimationFrame(frameId);
       }
     };
-  }, [state.isPlaying, trace, maxDurationMs, onVictory, onDraw, onTimeout, onMatchEnd]);
+  }, [
+    state.isPlaying,
+    trace,
+    maxDurationMs,
+    onVictory,
+    onDraw,
+    onTimeout,
+    onMatchEnd,
+  ]);
 
   return state;
 }

--- a/src/hooks/useMatchTimeline.ts
+++ b/src/hooks/useMatchTimeline.ts
@@ -11,11 +11,11 @@
  * - Handle pause/play/seek controls
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import { interpolateAllEntities } from '../systems/matchTrace/interpolator';
-import { MatchPlayer, PlaybackState } from '../systems/matchTrace/matchPlayer';
-import type { MatchTrace, MatchTraceEvent } from '../systems/matchTrace/types';
+import { interpolateAllEntities } from "../systems/matchTrace/interpolator";
+import { MatchPlayer, PlaybackState } from "../systems/matchTrace/matchPlayer";
+import type { MatchTrace, MatchTraceEvent } from "../systems/matchTrace/types";
 
 // ============================================================================
 // Types
@@ -204,7 +204,14 @@ export function useInterpolatedEntities(
   entityIds?: string[],
 ) {
   return useState(() => {
-    const eventsBefore = trace.events.filter((e) => e.timestampMs <= currentTimestamp);
-    return interpolateAllEntities(trace.events, eventsBefore, currentTimestamp, entityIds);
+    const eventsBefore = trace.events.filter(
+      (e) => e.timestampMs <= currentTimestamp,
+    );
+    return interpolateAllEntities(
+      trace.events,
+      eventsBefore,
+      currentTimestamp,
+      entityIds,
+    );
   })[0];
 }

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -185,6 +185,13 @@
   justify-content: center;
 }
 
+.control-strip__quality {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 .control-strip__button {
   border: none;
   border-radius: 999px;
@@ -197,6 +204,17 @@
   transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
   background: linear-gradient(135deg, rgba(123, 163, 255, 0.92), rgba(119, 94, 255, 0.92));
   box-shadow: 0 14px 28px rgba(74, 91, 255, 0.35);
+}
+
+.control-strip__button--quality {
+  background: rgba(255, 255, 255, 0.08);
+  color: #dbe4ff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.control-strip__button--quality-active {
+  background: linear-gradient(135deg, rgba(123, 163, 255, 0.92), rgba(119, 94, 255, 0.92));
+  box-shadow: 0 12px 24px rgba(74, 91, 255, 0.32);
 }
 
 .control-strip__button:disabled {

--- a/src/systems/matchTrace/assetLoader.ts
+++ b/src/systems/matchTrace/assetLoader.ts
@@ -11,13 +11,13 @@
  * 4. Cache result for reuse
  */
 
-import { BoxGeometry, CylinderGeometry, SphereGeometry } from 'three';
+import { BoxGeometry, CylinderGeometry, SphereGeometry } from "three";
 
 // ============================================================================
 // Asset Types
 // ============================================================================
 
-export type AssetType = 'robot' | 'projectile' | 'effect' | 'environment';
+export type AssetType = "robot" | "projectile" | "effect" | "environment";
 
 export interface LoadedAsset {
   id: string;
@@ -48,7 +48,9 @@ class AssetLoader {
     const startTime = performance.now();
 
     // Try to load from asset bundle (placeholder for now)
-    const asset = await this.tryLoadModel(id).catch(() => this.getFallbackAsset(id, type));
+    const asset = await this.tryLoadModel(id).catch(() =>
+      this.getFallbackAsset(id, type),
+    );
 
     const loadTime = performance.now() - startTime;
     asset.loadTime = loadTime;
@@ -80,22 +82,22 @@ class AssetLoader {
     let geometry: BoxGeometry | SphereGeometry | CylinderGeometry;
 
     switch (type) {
-      case 'robot':
+      case "robot":
         // Simple box for robot
         geometry = new BoxGeometry(0.5, 1.0, 0.5);
         break;
 
-      case 'projectile':
+      case "projectile":
         // Sphere for projectile
         geometry = new SphereGeometry(0.1, 8, 8);
         break;
 
-      case 'effect':
+      case "effect":
         // Octahedron-like effect (using sphere simplified)
         geometry = new SphereGeometry(0.3, 4, 4);
         break;
 
-      case 'environment':
+      case "environment":
         // Default plane/box for environment
         geometry = new BoxGeometry(10, 1, 10);
         break;
@@ -136,7 +138,10 @@ class AssetLoader {
   /**
    * Get cache statistics for debugging.
    */
-  getStats(): { cacheSize: number; assets: Array<{ id: string; loadTime: number; isFallback: boolean }> } {
+  getStats(): {
+    cacheSize: number;
+    assets: Array<{ id: string; loadTime: number; isFallback: boolean }>;
+  } {
     const assets = Array.from(this.cache.values()).map((asset) => ({
       id: asset.id,
       loadTime: asset.loadTime,

--- a/src/systems/matchTrace/contractValidator.ts
+++ b/src/systems/matchTrace/contractValidator.ts
@@ -8,12 +8,15 @@
  * Schemas: specs/003-extend-placeholder-create/schemas/
  */
 
- 
-import type { ErrorObject } from 'ajv';
+import type { ErrorObject } from "ajv";
 // eslint-disable-next-line import/no-extraneous-dependencies
-import Ajv from 'ajv';
+import Ajv from "ajv";
 
-import { ContractValidationReport, ValidationError, ValidationResult } from './types';
+import {
+  ContractValidationReport,
+  ValidationError,
+  ValidationResult,
+} from "./types";
 
 const ajv = new Ajv();
 
@@ -22,49 +25,49 @@ const ajv = new Ajv();
 // ============================================================================
 
 const TEAM_SCHEMA = {
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  title: 'Team',
-  type: 'object',
-  required: ['id', 'name', 'units', 'spawnPoints'],
+  $schema: "http://json-schema.org/draft-07/schema#",
+  title: "Team",
+  type: "object",
+  required: ["id", "name", "units", "spawnPoints"],
   properties: {
-    id: { type: 'string' },
-    name: { type: 'string' },
-    metadata: { type: 'object' },
+    id: { type: "string" },
+    name: { type: "string" },
+    metadata: { type: "object" },
     units: {
-      type: 'array',
+      type: "array",
       items: {
         anyOf: [
-          { type: 'string' },
+          { type: "string" },
           {
-            type: 'object',
-            required: ['id', 'modelRef', 'teamId', 'maxHealth'],
+            type: "object",
+            required: ["id", "modelRef", "teamId", "maxHealth"],
             properties: {
-              id: { type: 'string' },
-              modelRef: { type: 'string' },
-              teamId: { type: 'string' },
-              maxHealth: { type: 'number' },
-              currentHealth: { type: 'number' },
-              weapons: { type: 'array' },
-              isCaptain: { type: 'boolean' },
+              id: { type: "string" },
+              modelRef: { type: "string" },
+              teamId: { type: "string" },
+              maxHealth: { type: "number" },
+              currentHealth: { type: "number" },
+              weapons: { type: "array" },
+              isCaptain: { type: "boolean" },
             },
           },
         ],
       },
     },
     spawnPoints: {
-      type: 'array',
+      type: "array",
       items: {
-        type: 'object',
-        required: ['spawnPointId', 'position'],
+        type: "object",
+        required: ["spawnPointId", "position"],
         properties: {
-          spawnPointId: { type: 'string' },
+          spawnPointId: { type: "string" },
           position: {
-            type: 'object',
-            required: ['x', 'y', 'z'],
+            type: "object",
+            required: ["x", "y", "z"],
             properties: {
-              x: { type: 'number' },
-              y: { type: 'number' },
-              z: { type: 'number' },
+              x: { type: "number" },
+              y: { type: "number" },
+              z: { type: "number" },
             },
           },
         },
@@ -75,61 +78,61 @@ const TEAM_SCHEMA = {
 };
 
 const MATCHTRACE_SCHEMA = {
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  title: 'MatchTrace',
-  type: 'object',
-  required: ['events'],
+  $schema: "http://json-schema.org/draft-07/schema#",
+  title: "MatchTrace",
+  type: "object",
+  required: ["events"],
   properties: {
     meta: {
-      type: 'object',
+      type: "object",
       properties: {
-        rngSeed: { type: 'integer' },
-        rngAlgorithm: { type: 'string' },
+        rngSeed: { type: "integer" },
+        rngAlgorithm: { type: "string" },
       },
       additionalProperties: true,
     },
-    rngSeed: { type: 'integer' },
-    rngAlgorithm: { type: 'string' },
+    rngSeed: { type: "integer" },
+    rngAlgorithm: { type: "string" },
     events: {
-      type: 'array',
+      type: "array",
       items: {
-        type: 'object',
-        required: ['type', 'timestampMs'],
+        type: "object",
+        required: ["type", "timestampMs"],
         properties: {
           type: {
-            type: 'string',
-            enum: ['spawn', 'move', 'fire', 'hit', 'damage', 'death', 'score'],
+            type: "string",
+            enum: ["spawn", "move", "fire", "hit", "damage", "death", "score"],
           },
-          timestampMs: { type: 'integer' },
-          frameIndex: { type: 'integer' },
-          sequenceId: { type: 'integer' },
-          entityId: { type: 'string' },
-          attackerId: { type: 'string' },
-          targetId: { type: 'string' },
-          teamId: { type: 'string' },
+          timestampMs: { type: "integer" },
+          frameIndex: { type: "integer" },
+          sequenceId: { type: "integer" },
+          entityId: { type: "string" },
+          attackerId: { type: "string" },
+          targetId: { type: "string" },
+          teamId: { type: "string" },
           position: {
-            type: 'object',
+            type: "object",
             properties: {
-              x: { type: 'number' },
-              y: { type: 'number' },
-              z: { type: 'number' },
+              x: { type: "number" },
+              y: { type: "number" },
+              z: { type: "number" },
             },
-            required: ['x', 'y', 'z'],
+            required: ["x", "y", "z"],
           },
-          projectileId: { type: 'string' },
+          projectileId: { type: "string" },
           collisionNormal: {
-            type: 'object',
+            type: "object",
             properties: {
-              x: { type: 'number' },
-              y: { type: 'number' },
-              z: { type: 'number' },
+              x: { type: "number" },
+              y: { type: "number" },
+              z: { type: "number" },
             },
           },
-          amount: { type: 'number' },
-          resultingHealth: { type: 'number' },
-          sourceEventId: { type: 'string' },
-          reason: { type: 'string' },
-          killedBy: { type: 'string' },
+          amount: { type: "number" },
+          resultingHealth: { type: "number" },
+          sourceEventId: { type: "string" },
+          reason: { type: "string" },
+          killedBy: { type: "string" },
         },
         additionalProperties: true,
       },
@@ -151,16 +154,26 @@ const validateMatchTrace = ajv.compile(MATCHTRACE_SCHEMA);
 /**
  * Convert ajv validation errors to our ValidationError format
  */
-function formatErrors(errors: ErrorObject[] | null | undefined): ValidationError[] {
+function formatErrors(
+  errors: ErrorObject[] | null | undefined,
+): ValidationError[] {
   if (!errors || errors.length === 0) {
     return [];
   }
 
-  return errors.map((err) => ({
-    path: err.instancePath || err.schemaPath || 'root',
-    message: err.message || 'Unknown validation error',
-    value: err.data,
-  }));
+  return errors.map((err) => {
+    const errorRecord = err as unknown as Record<string, unknown>;
+    const instancePath =
+      typeof errorRecord.instancePath === "string"
+        ? (errorRecord.instancePath as string)
+        : undefined;
+
+    return {
+      path: instancePath || err.dataPath || err.schemaPath || "root",
+      message: err.message || "Unknown validation error",
+      value: err.data,
+    };
+  });
 }
 
 /**
@@ -215,8 +228,12 @@ export function validateAllContracts(
   team?: unknown,
   trace?: unknown,
 ): ContractValidationReport {
-  const teamResult = team ? validateTeamContract(team) : { valid: true, errors: [] };
-  const traceResult = trace ? validateMatchTraceContract(trace) : { valid: true, errors: [] };
+  const teamResult = team
+    ? validateTeamContract(team)
+    : { valid: true, errors: [] };
+  const traceResult = trace
+    ? validateMatchTraceContract(trace)
+    : { valid: true, errors: [] };
 
   const overallValid = teamResult.valid && traceResult.valid;
 
@@ -235,11 +252,14 @@ export function validateAllContracts(
  * @param context - Human-readable context for the error message
  * @throws Error if validation failed
  */
-export function assertContractValid(result: ValidationResult, context: string): void {
+export function assertContractValid(
+  result: ValidationResult,
+  context: string,
+): void {
   if (!result.valid) {
     const errorList = result.errors
       .map((err) => `  - ${err.path}: ${err.message}`)
-      .join('\n');
+      .join("\n");
     throw new Error(`Contract validation failed (${context}):\n${errorList}`);
   }
 }

--- a/src/systems/matchTrace/entityMapper.ts
+++ b/src/systems/matchTrace/entityMapper.ts
@@ -18,7 +18,7 @@ import type {
   MoveEvent,
   SpawnEvent,
   Unit,
-} from './types';
+} from "./types";
 
 // ============================================================================
 // Types & State
@@ -27,7 +27,7 @@ import type {
 export interface EntityState {
   id: string;
   teamId: string;
-  type: 'robot' | 'projectile';
+  type: "robot" | "projectile";
   spawnedAt: number; // timestampMs
   diedAt?: number; // timestampMs if dead
   currentHealth?: number;
@@ -88,12 +88,12 @@ export class EntityMapper {
    */
   private processEvent(event: MatchTraceEvent): void {
     switch (event.type) {
-      case 'spawn': {
+      case "spawn": {
         const spawnEvent = event as SpawnEvent;
         const entity: EntityState = {
-          id: spawnEvent.entityId || 'unknown',
-          teamId: spawnEvent.teamId || 'unknown',
-          type: 'robot',
+          id: spawnEvent.entityId || "unknown",
+          teamId: spawnEvent.teamId || "unknown",
+          type: "robot",
           spawnedAt: spawnEvent.timestampMs,
           isAlive: true,
           position: spawnEvent.position,
@@ -103,18 +103,18 @@ export class EntityMapper {
         break;
       }
 
-      case 'move': {
+      case "move": {
         const moveEvent = event as MoveEvent;
-        const entity = this.entities.get(moveEvent.entityId || 'unknown');
+        const entity = this.entities.get(moveEvent.entityId || "unknown");
         if (entity) {
           entity.position = moveEvent.position;
         }
         break;
       }
 
-      case 'damage': {
+      case "damage": {
         const damageEvent = event as DamageEvent;
-        const entity = this.entities.get(damageEvent.targetId || 'unknown');
+        const entity = this.entities.get(damageEvent.targetId || "unknown");
         if (entity) {
           entity.currentHealth = damageEvent.resultingHealth;
           entity.maxHealth = entity.maxHealth ?? damageEvent.resultingHealth;
@@ -122,9 +122,9 @@ export class EntityMapper {
         break;
       }
 
-      case 'death': {
+      case "death": {
         const deathEvent = event as DeathEvent;
-        const entity = this.entities.get(deathEvent.entityId || 'unknown');
+        const entity = this.entities.get(deathEvent.entityId || "unknown");
         if (entity) {
           entity.isAlive = false;
           entity.diedAt = deathEvent.timestampMs;
@@ -133,10 +133,10 @@ export class EntityMapper {
       }
 
       // Other event types don't change entity state (intentional fall-through)
-      case 'fire':
-      case 'hit':
-      case 'score':
-        // eslint-disable-next-line no-fallthrough
+      case "fire":
+      case "hit":
+      case "score":
+      // eslint-disable-next-line no-fallthrough
       default:
         // No-op for rendering purposes
         break;
@@ -168,7 +168,9 @@ export class EntityMapper {
    * Get entities by team ID.
    */
   public getEntitiesByTeam(teamId: string): EntityState[] {
-    return Array.from(this.entities.values()).filter((e) => e.teamId === teamId);
+    return Array.from(this.entities.values()).filter(
+      (e) => e.teamId === teamId,
+    );
   }
 
   /**
@@ -207,7 +209,7 @@ export function entityStateFromUnit(
   return {
     id: unit.id,
     teamId: unit.teamId,
-    type: 'robot',
+    type: "robot",
     spawnedAt,
     isAlive: true,
     position,

--- a/src/systems/matchTrace/interpolator.ts
+++ b/src/systems/matchTrace/interpolator.ts
@@ -12,7 +12,7 @@
  * - Cache and update interpolation state efficiently
  */
 
-import type { MatchTraceEvent, MoveEvent, Position, SpawnEvent } from './types';
+import type { MatchTraceEvent, MoveEvent, Position, SpawnEvent } from "./types";
 
 // ============================================================================
 // Types
@@ -57,16 +57,16 @@ export function buildInterpolationState(
   // Scan events in order
   for (const event of events) {
     // Check if event has entityId property (spawn, move, death)
-    const hasEntityId = 'entityId' in event;
+    const hasEntityId = "entityId" in event;
     if (hasEntityId && (event as { entityId: string }).entityId === entityId) {
-      if (event.type === 'spawn') {
+      if (event.type === "spawn") {
         const spawnEvent = event as SpawnEvent;
         isAlive = true;
         lastSpawnTime = spawnEvent.timestampMs;
-      } else if (event.type === 'death') {
+      } else if (event.type === "death") {
         isAlive = false;
         lastDeathTime = event.timestampMs;
-      } else if (event.type === 'move') {
+      } else if (event.type === "move") {
         lastMoveEvent = event as MoveEvent;
       }
     }
@@ -95,11 +95,11 @@ export function getNextMoveEvent(
   afterTimestamp: number,
 ): MoveEvent | undefined {
   for (const event of allEvents) {
-    const hasEntityId = 'entityId' in event;
+    const hasEntityId = "entityId" in event;
     if (
       hasEntityId &&
       (event as { entityId: string }).entityId === entityId &&
-      event.type === 'move' &&
+      event.type === "move" &&
       event.timestampMs > afterTimestamp
     ) {
       return event as MoveEvent;
@@ -155,7 +155,10 @@ export function interpolateEntity(
   // If no move event yet, use spawn position
   if (!state.lastMoveEvent) {
     const spawnEvent = eventsBefore.find(
-      (e) => 'entityId' in e && (e as { entityId: string }).entityId === entityId && e.type === 'spawn',
+      (e) =>
+        "entityId" in e &&
+        (e as { entityId: string }).entityId === entityId &&
+        e.type === "spawn",
     ) as SpawnEvent | undefined;
     if (spawnEvent) {
       return {
@@ -174,7 +177,11 @@ export function interpolateEntity(
   }
 
   // Find next move event for interpolation target
-  const nextMove = getNextMoveEvent(allEvents, entityId, state.lastMoveEvent.timestampMs);
+  const nextMove = getNextMoveEvent(
+    allEvents,
+    entityId,
+    state.lastMoveEvent.timestampMs,
+  );
 
   if (!nextMove) {
     // No next move, use last position
@@ -227,7 +234,7 @@ export function interpolateAllEntities(
   if (!idsToInterpolate) {
     const idSet = new Set<string>();
     for (const event of allEvents) {
-      if ('entityId' in event) {
+      if ("entityId" in event) {
         idSet.add((event as { entityId: string }).entityId);
       }
     }
@@ -236,7 +243,12 @@ export function interpolateAllEntities(
 
   const result = new Map<string, InterpolatedEntity>();
   for (const id of idsToInterpolate) {
-    const interpolated = interpolateEntity(allEvents, eventsBefore, id, currentTimestamp);
+    const interpolated = interpolateEntity(
+      allEvents,
+      eventsBefore,
+      id,
+      currentTimestamp,
+    );
     result.set(id, interpolated);
   }
 

--- a/src/systems/matchTrace/liveTraceEmitter.ts
+++ b/src/systems/matchTrace/liveTraceEmitter.ts
@@ -1,0 +1,67 @@
+import type { Position } from "./types";
+
+export type LiveTraceSpawnEvent = {
+  type: "spawn";
+  entityId: string;
+  teamId: string;
+  position: Position;
+  timestampMs: number;
+};
+
+export type LiveTraceFireEvent = {
+  type: "fire";
+  attackerId: string;
+  projectileId: string;
+  position: Position;
+  timestampMs: number;
+};
+
+export type LiveTraceDamageEvent = {
+  type: "damage";
+  targetId: string;
+  attackerId?: string;
+  amount: number;
+  resultingHealth: number;
+  timestampMs: number;
+};
+
+export type LiveTraceDeathEvent = {
+  type: "death";
+  entityId: string;
+  killedBy?: string;
+  timestampMs: number;
+};
+
+export type LiveTraceEvent =
+  | LiveTraceSpawnEvent
+  | LiveTraceFireEvent
+  | LiveTraceDamageEvent
+  | LiveTraceDeathEvent;
+
+type LiveTraceListener = (event: LiveTraceEvent) => void;
+
+const listeners = new Set<LiveTraceListener>();
+
+export function emitLiveTraceEvent(event: LiveTraceEvent): void {
+  listeners.forEach((listener) => {
+    try {
+      listener(event);
+    } catch (error) {
+      // Listener errors should not break simulation; log for visibility.
+      console.error("[live-trace] listener error", error);
+    }
+  });
+}
+
+export function subscribeLiveTraceEvents(
+  listener: LiveTraceListener,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function clearLiveTraceListeners(): void {
+  listeners.clear();
+}

--- a/src/systems/matchTrace/matchPlayer.ts
+++ b/src/systems/matchTrace/matchPlayer.ts
@@ -12,23 +12,23 @@
  * - Debug mode: frame-step mode with event inspection
  */
 
-import { RNG_ALGORITHM_ID,RNGManager } from './rngManager';
-import { MatchTrace, MatchTraceEvent } from './types';
+import { RNG_ALGORITHM_ID, RNGManager } from "./rngManager";
+import { MatchTrace, MatchTraceEvent } from "./types";
 
 // ============================================================================
 // Types & Constants
 // ============================================================================
 
 export enum PlaybackState {
-  Idle = 'idle',
-  Playing = 'playing',
-  Paused = 'paused',
-  Finished = 'finished',
+  Idle = "idle",
+  Playing = "playing",
+  Paused = "paused",
+  Finished = "finished",
 }
 
 export enum ReplayMode {
-  Live = 'live', // Normal trace playback without RNG seeding
-  Deterministic = 'deterministic', // Replay with RNG seed for exact reproduction
+  Live = "live", // Normal trace playback without RNG seeding
+  Deterministic = "deterministic", // Replay with RNG seed for exact reproduction
 }
 
 export interface MatchPlayerConfig {
@@ -152,7 +152,9 @@ export class MatchPlayer {
     }
 
     // Update frame index based on current timestamp
-    this.currentFrameIndex = this.findFrameIndexAtTimestamp(this.currentTimestampMs);
+    this.currentFrameIndex = this.findFrameIndexAtTimestamp(
+      this.currentTimestampMs,
+    );
   }
 
   /**
@@ -163,7 +165,9 @@ export class MatchPlayer {
   public seek(timestampMs: number): void {
     const maxTs = this.getMaxTimestamp();
     this.currentTimestampMs = Math.max(0, Math.min(timestampMs, maxTs));
-    this.currentFrameIndex = this.findFrameIndexAtTimestamp(this.currentTimestampMs);
+    this.currentFrameIndex = this.findFrameIndexAtTimestamp(
+      this.currentTimestampMs,
+    );
 
     // If at end, mark as finished
     if (this.currentTimestampMs >= maxTs) {
@@ -177,7 +181,7 @@ export class MatchPlayer {
    */
   public stepFrame(): void {
     if (!this.debugMode) {
-      console.warn('MatchPlayer.stepFrame() only available in debugMode');
+      console.warn("MatchPlayer.stepFrame() only available in debugMode");
       return;
     }
 
@@ -195,7 +199,9 @@ export class MatchPlayer {
    * Get current playback snapshot.
    */
   public getSnapshot(): PlaybackSnapshot {
-    const eventsAtTimestamp = this.getEventsAtTimestamp(this.currentTimestampMs);
+    const eventsAtTimestamp = this.getEventsAtTimestamp(
+      this.currentTimestampMs,
+    );
     const maxTs = this.getMaxTimestamp();
     const progress = maxTs > 0 ? this.currentTimestampMs / maxTs : 0;
 
@@ -354,7 +360,8 @@ export class MatchPlayer {
     if (!traceSeed || !traceAlgo) {
       return {
         valid: false,
-        warning: 'Trace missing RNG metadata. Deterministic replay may not be reproducible.',
+        warning:
+          "Trace missing RNG metadata. Deterministic replay may not be reproducible.",
       };
     }
 
@@ -382,4 +389,3 @@ export class MatchPlayer {
     return this.rngManager?.getCallCount() ?? 0;
   }
 }
-

--- a/src/systems/matchTrace/matchValidator.ts
+++ b/src/systems/matchTrace/matchValidator.ts
@@ -9,18 +9,18 @@
  * Used by MatchPlayer and useMatchSimulation to trigger victory state.
  */
 
-import type { EntityState } from './entityMapper';
-import type { MatchTrace } from './types';
+import type { EntityState } from "./entityMapper";
+import type { MatchTrace } from "./types";
 
 // ============================================================================
 // Match Result Types
 // ============================================================================
 
 export enum MatchOutcome {
-  InProgress = 'in-progress',
-  Victory = 'victory',
-  Draw = 'draw',
-  Timeout = 'timeout',
+  InProgress = "in-progress",
+  Victory = "victory",
+  Draw = "draw",
+  Timeout = "timeout",
 }
 
 export interface MatchResult {
@@ -59,7 +59,7 @@ export function validateMatchOutcome(
       outcome: MatchOutcome.Timeout,
       survivors: aliveEntities,
       timestamp: currentTimestampMs,
-      reason: 'Match time limit reached',
+      reason: "Match time limit reached",
     };
   }
 
@@ -69,7 +69,7 @@ export function validateMatchOutcome(
       outcome: MatchOutcome.Draw,
       survivors: [],
       timestamp: currentTimestampMs,
-      reason: 'All units eliminated',
+      reason: "All units eliminated",
     };
   }
 
@@ -159,13 +159,13 @@ export function formatMatchResult(result: MatchResult): string {
     case MatchOutcome.Victory:
       return `🎉 Team ${result.winnerId} Victory! (${result.survivors?.length ?? 0} survivors)`;
     case MatchOutcome.Draw:
-      return '🤝 Match Ended in Draw';
+      return "🤝 Match Ended in Draw";
     case MatchOutcome.Timeout:
-      return '⏱️ Match Time Limit Reached (Draw)';
+      return "⏱️ Match Time Limit Reached (Draw)";
     case MatchOutcome.InProgress:
       return `⚔️ Match In Progress (${result.survivors?.length ?? 0} units alive)`;
     default:
-      return '❓ Unknown Match State';
+      return "❓ Unknown Match State";
   }
 }
 
@@ -179,7 +179,10 @@ export function formatMatchResult(result: MatchResult): string {
  * @param aliveEntities — Current alive entities
  * @returns Winning team ID if match is finished, undefined otherwise
  */
-export function findWinningTeam(trace: MatchTrace, aliveEntities: EntityState[]): string | undefined {
+export function findWinningTeam(
+  trace: MatchTrace,
+  aliveEntities: EntityState[],
+): string | undefined {
   if (aliveEntities.length === 0) {
     return undefined;
   }

--- a/src/systems/matchTrace/rngManager.ts
+++ b/src/systems/matchTrace/rngManager.ts
@@ -16,7 +16,7 @@
 // Constants & Algorithm Identification
 // ============================================================================
 
-export const RNG_ALGORITHM_ID = 'xorshift32-v1';
+export const RNG_ALGORITHM_ID = "xorshift32-v1";
 export const RNG_ALGORITHM_VERSION = 1;
 
 // ============================================================================
@@ -55,7 +55,7 @@ export class RNGManager {
     if (this.seed === 0) {
       this.seed = 1;
       console.warn(
-        'RNGManager: seed was 0, reset to 1. xorshift32 requires non-zero seed.',
+        "RNGManager: seed was 0, reset to 1. xorshift32 requires non-zero seed.",
       );
     }
 
@@ -220,7 +220,7 @@ export function initializeGlobalRNG(seed: number): RNGManager {
 export function getGlobalRNG(): RNGManager {
   if (!globalRNG) {
     throw new Error(
-      'Global RNG not initialized. Call initializeGlobalRNG(seed) first.',
+      "Global RNG not initialized. Call initializeGlobalRNG(seed) first.",
     );
   }
   return globalRNG;

--- a/src/systems/matchTrace/types.ts
+++ b/src/systems/matchTrace/types.ts
@@ -51,7 +51,14 @@ export interface Team {
 // MatchTrace Events (from specs/003 Event Stream)
 // ============================================================================
 
-export type EventType = 'spawn' | 'move' | 'fire' | 'hit' | 'damage' | 'death' | 'score';
+export type EventType =
+  | "spawn"
+  | "move"
+  | "fire"
+  | "hit"
+  | "damage"
+  | "death"
+  | "score";
 
 export interface BaseEvent {
   type: EventType;
@@ -61,27 +68,27 @@ export interface BaseEvent {
 }
 
 export interface SpawnEvent extends BaseEvent {
-  type: 'spawn';
+  type: "spawn";
   entityId: string;
   teamId: string;
   position: Position;
 }
 
 export interface MoveEvent extends BaseEvent {
-  type: 'move';
+  type: "move";
   entityId: string;
   position: Position;
 }
 
 export interface FireEvent extends BaseEvent {
-  type: 'fire';
+  type: "fire";
   attackerId: string;
   projectileId: string;
   position: Position;
 }
 
 export interface HitEvent extends BaseEvent {
-  type: 'hit';
+  type: "hit";
   projectileId: string;
   targetId: string;
   position: Position;
@@ -89,7 +96,7 @@ export interface HitEvent extends BaseEvent {
 }
 
 export interface DamageEvent extends BaseEvent {
-  type: 'damage';
+  type: "damage";
   targetId: string;
   attackerId: string;
   amount: number;
@@ -98,13 +105,13 @@ export interface DamageEvent extends BaseEvent {
 }
 
 export interface DeathEvent extends BaseEvent {
-  type: 'death';
+  type: "death";
   entityId: string;
   killedBy?: string;
 }
 
 export interface ScoreEvent extends BaseEvent {
-  type: 'score';
+  type: "score";
   teamId: string;
   amount: number;
   reason?: string;
@@ -141,9 +148,9 @@ export interface MatchTrace {
 // ============================================================================
 
 export enum VisualQualityLevel {
-  High = 'high',
-  Medium = 'medium',
-  Low = 'low',
+  High = "high",
+  Medium = "medium",
+  Low = "low",
 }
 
 export interface VisualQualityProfile {
@@ -173,7 +180,7 @@ export interface ReplayConfig {
 
 export interface RenderedEntity {
   id: string;
-  type: 'robot' | 'projectile';
+  type: "robot" | "projectile";
   teamId?: string;
   position: Position;
   velocity?: Position;

--- a/src/systems/matchTrace/visualQualityProfile.ts
+++ b/src/systems/matchTrace/visualQualityProfile.ts
@@ -14,8 +14,8 @@
  * Output: VisualQualityProfile configuration for renderer
  */
 
-import type { VisualQualityLevel, VisualQualityProfile } from './types';
-import { VisualQualityLevel as QLvl } from './types';
+import type { VisualQualityLevel, VisualQualityProfile } from "./types";
+import { VisualQualityLevel as QLvl } from "./types";
 
 // ============================================================================
 // Quality Profile Factory
@@ -27,7 +27,9 @@ import { VisualQualityLevel as QLvl } from './types';
  * @param level - Quality level (high, medium, low)
  * @returns Configured VisualQualityProfile with all settings
  */
-export function createQualityProfile(level: VisualQualityLevel): VisualQualityProfile {
+export function createQualityProfile(
+  level: VisualQualityLevel,
+): VisualQualityProfile {
   switch (level) {
     case QLvl.High:
       return {
@@ -73,9 +75,8 @@ export function createQualityProfile(level: VisualQualityLevel): VisualQualityPr
 export const DEFAULT_QUALITY_LEVEL: VisualQualityLevel = QLvl.Medium;
 
 /** Default quality profile (Medium mode) */
-export const DEFAULT_QUALITY_PROFILE: VisualQualityProfile = createQualityProfile(
-  DEFAULT_QUALITY_LEVEL,
-);
+export const DEFAULT_QUALITY_PROFILE: VisualQualityProfile =
+  createQualityProfile(DEFAULT_QUALITY_LEVEL);
 
 // ============================================================================
 // Quality Helper Functions
@@ -169,16 +170,16 @@ export function getTrailComplexity(level: VisualQualityLevel): number {
  */
 export function isFeatureEnabled(
   profile: VisualQualityProfile,
-  feature: 'shadows' | 'textures' | 'particles' | 'postProcessing',
+  feature: "shadows" | "textures" | "particles" | "postProcessing",
 ): boolean {
   switch (feature) {
-    case 'shadows':
+    case "shadows":
       return profile.shadowsEnabled;
-    case 'textures':
+    case "textures":
       return profile.texturesEnabled;
-    case 'particles':
+    case "particles":
       return profile.particlesEnabled;
-    case 'postProcessing':
+    case "postProcessing":
       return profile.postProcessingEnabled;
     default:
       return false;
@@ -195,6 +196,8 @@ export function isFeatureEnabled(
  * @param value - Value to check
  * @returns true if valid level, false otherwise
  */
-export function isValidQualityLevel(value: unknown): value is VisualQualityLevel {
+export function isValidQualityLevel(
+  value: unknown,
+): value is VisualQualityLevel {
   return value === QLvl.High || value === QLvl.Medium || value === QLvl.Low;
 }


### PR DESCRIPTION
## Summary
- multiplex test frame subscriptions so physics sync and trace capture share a single hook while skipping 3D rendering during tests
- refactor MatchSceneInner into a Canvas-only renderer and update robot/projectile components to guard useFrame access outside Canvas
- harden contract validation error formatting for legacy ajv typings

## Testing
- npm run lint
- npx tsc --noEmit
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f3d5c195fc832aa705cbf2ce57e8a9