### PR TITLE
Add refactor plan and task list for core match runtime

### DIFF
--- a/specs/003-extend-placeholder-create/plan-refactor.md
+++ b/specs/003-extend-placeholder-create/plan-refactor.md
@@ -1,0 +1,52 @@
+# Refactor Plan: Address Tech Debt in Core Match Runtime
+
+## Objective
+Create a staged refactor that resolves the five high-priority tech debt items identified in `docs/tech-debt-refactor-report.md` while preserving the functional and visual requirements captured in feature specs `001`, `002`, and `003`. The outcome should be a modular runtime that cleanly separates layout, simulation orchestration, AI decision making, combat resolution, and rendering.
+
+## Inputs Consolidated from Existing Specs
+- **Autobattler simulation requirements (Spec 001)**: deterministic 10v10 spawns, captain election rules, adaptive AI behavior, weapon triangle balance, victory announcement flow, and space-station arena presentation. 【F:specs/001-3d-team-vs/spec.md†L1-L48】
+- **Graphics and UI orchestration requirements (Spec 002)**: round-state HUD transitions, quality scaling knobs, camera/spectator modes, and hybrid event + snapshot data delivery. 【F:specs/002-3d-simulation-graphics/spec.md†L1-L58】
+- **Integration and replay guarantees (Spec 003)**: renderer/simulation synchronization, MatchTrace schema, deterministic replays, and quality configuration inheritance. 【F:specs/003-extend-placeholder-create/spec.md†L1-L74】
+
+These specs collectively require that any refactor maintain deterministic simulation outputs, configurable graphics, responsive HUD transitions, and match trace fidelity while improving maintainability.
+
+## Refactor Pillars
+1. **Application shell modularization (addresses App.tsx debt)**
+   - Extract layout primitives (grid, sidebar, HUD container) into presentational components so that `App` coordinates routing/data loading only.
+   - Isolate HUD visibility and quality toggle state into a dedicated UI state store (leveraging existing Redux/Zustand-equivalent infrastructure if available) aligned with Spec 002 latency expectations.
+   - Move inline styles to themed style modules (CSS modules or styled system) to unlock reuse for multiple screens.
+
+2. **Simulation orchestration boundaries (addresses Simulation.tsx debt)**
+   - Introduce a `useMatchRuntime` hook responsible for ECS lifecycle (bootstrap, run loop, pause/resume) and event publication (MatchTrace, quality change notifications) to align with Specs 002/003 hybrid data delivery.
+   - Convert `Simulation` component into a thin render orchestrator that subscribes to runtime events, feeds data into scene graph components, and exposes debug controls.
+   - Define domain modules (`runtime/worldSetup.ts`, `runtime/stateTransitions.ts`) so that game flow logic becomes testable.
+
+3. **AI behavior modules (addresses aiSystem.ts debt)**
+   - Split AI into `targeting`, `behaviorState`, and `pathing` modules. Each module exposes pure functions operating on typed snapshots to satisfy Spec 001 captain election & adaptive strategy requirements.
+   - Implement explicit mode/state machine definitions (enums + transition tables) to make behavior switching auditable and replay friendly per Spec 003.
+   - Provide dependency injection for RNG and perception windows to ensure deterministic replays.
+
+4. **Combat systems separation (addresses weaponSystem.ts debt)**
+   - Move projectile lifecycle into a dedicated module (`projectiles/system.ts`) with optimized collision helpers (`collision/broadPhase.ts`, `collision/narrowPhase.ts`).
+   - Encapsulate weapon firing logic inside `weapons/firingController.ts` that reads from robot loadouts defined in Spec 001 data model.
+   - Standardize damage resolution and event emission to keep MatchTrace consistent.
+
+5. **Scene graph responsibility split (addresses Robots.tsx debt)**
+   - Introduce reusable `RobotMesh` and `RobotAnimator` components to isolate Three.js mesh creation, instancing, and animation timelines.
+   - Move animation side effects into render-loop hooks (`useRobotAnimation`) that pull from the simulation snapshot supplied by `useMatchRuntime`.
+   - Provide a batched entity subscription (`useRobotsForFrame`) to eliminate interval polling and leverage the main runtime loop.
+
+## Cross-Cutting Concerns
+- **Testing & Observability**: Ensure each extracted module exposes deterministic unit-testable APIs. Update Vitest suites to cover AI transitions, projectile collisions, and runtime state changes while preserving the `MatchTrace` schema contracts.
+- **Performance Budgets**: Enforce GPU instancing, LOD toggles, and quality scaling hooks defined in Spec 002 during refactor to avoid regressing frame times.
+- **Configuration & Replay**: Maintain RNG seed propagation, event ordering, and trace recording per Spec 003 when moving logic between modules.
+
+## Phased Delivery
+1. **Phase 1 – App & HUD shell**: Split layout, introduce UI state store, align HUD toggles with Spec 002 requirements.
+2. **Phase 2 – Runtime hook extraction**: Carve out `useMatchRuntime` and supporting modules from `Simulation.tsx`; update component tree accordingly.
+3. **Phase 3 – AI module refactor**: Separate targeting and behavior state machine, update references, add unit tests for captain reassignment and behavior transitions.
+4. **Phase 4 – Combat systems refactor**: Create dedicated weapon/projectile modules, optimize collision loops, validate MatchTrace events.
+5. **Phase 5 – Scene graph modularization**: Replace `RobotActor` monolith with mesh + animation primitives and integrate with runtime snapshots.
+6. **Phase 6 – Regression hardening**: Expand tests, run performance/visual smoke tests, verify deterministic replays, and document module interfaces for future contributors.
+
+Each phase should land via incremental PRs that keep the game runnable, with feature flags or branch toggles if necessary.

--- a/specs/003-extend-placeholder-create/task-refactor.md
+++ b/specs/003-extend-placeholder-create/task-refactor.md
@@ -1,0 +1,70 @@
+# Refactor Task Breakdown: Core Match Runtime
+
+## Phase 1 – Application Shell & HUD State
+1. **Extract layout primitives**
+   - Create `src/ui/layout/AppLayout.tsx` with grid + sidebar structure.
+   - Move HUD containers into `src/ui/hud/HudShell.tsx`; expose props for visibility flags.
+   - Replace inline styles in `App.tsx` with imports from `AppLayout`.
+2. **Centralize UI state**
+   - Introduce `src/state/ui/hudStore.ts` (Zustand/Recoil) to manage HUD visibility, camera mode, and quality settings with latency telemetry hooks per Spec 002.
+   - Update `App.tsx` and existing HUD toggles to read/write via the store.
+3. **Data loading boundary**
+   - Isolate initial fetch logic into `src/runtime/bootstrap/loadInitialMatch.ts`; ensure errors propagate through React Query/Suspense boundary.
+
+## Phase 2 – Simulation Runtime Extraction
+1. **Create `src/runtime/useMatchRuntime.ts`**
+   - Manage ECS world init, clock stepping, pause/resume, and disposal.
+   - Emit MatchTrace events via `onEvent` callbacks using the Spec 003 schema.
+2. **Split supporting modules**
+   - Add `src/runtime/world/setupWorld.ts` for entity/component registration.
+   - Add `src/runtime/state/matchStateMachine.ts` encapsulating paused/running/victory transitions.
+3. **Update `Simulation.tsx`**
+   - Consume `useMatchRuntime` for lifecycle.
+   - Remove direct ECS mutation; render-only responsibilities remain.
+
+## Phase 3 – AI Module Refactor
+1. **Carve out targeting helpers**
+   - Move `findClosestEnemy`, `pickCaptainTarget` into `src/simulation/ai/targeting.ts` with deterministic tie-breakers from Spec 001.
+2. **State machine clarification**
+   - Define `RobotBehaviorMode` enum and transition table in `src/simulation/ai/behaviorState.ts`.
+   - Export pure `nextBehaviorState(robotSnapshot, context)` function with RNG injection for deterministic replay per Spec 003.
+3. **Pathing & formation coordination**
+   - Extract movement vector calculations into `src/simulation/ai/pathing.ts` reusing captain alignment rules.
+4. **Update tests**
+   - Add Vitest suites covering captain reassignment, mode transitions, and deterministic outputs.
+
+## Phase 4 – Combat Systems Separation
+1. **Weapon firing controller**
+   - Implement `src/simulation/combat/weapons/firingController.ts` responsible for cooldown checks, ammo use, and event emission.
+2. **Projectile system module**
+   - Implement `src/simulation/combat/projectiles/system.ts` stepping projectile movement, life span, and hit detection.
+   - Introduce collision helpers under `src/simulation/combat/collision/` for broadphase AABB checks and narrowphase ray/mesh intersections.
+3. **Damage + trace integration**
+   - Move damage resolution into `src/simulation/combat/damageResolver.ts` that records MatchTrace events.
+4. **Update `weaponSystem.ts`**
+   - Refactor to orchestrate modules above; ensure `updateProjectileSystem` delegates to projectile module.
+5. **Tests**
+   - Add collision unit tests and golden MatchTrace event snapshots for multi-hit scenarios.
+
+## Phase 5 – Scene Graph Modularization
+1. **Mesh + material composition**
+   - Create `src/scene/robots/RobotMesh.tsx` returning instanced meshes per robot team.
+   - Extract material creation to `src/scene/robots/materials.ts` to apply quality scaling toggles.
+2. **Animation & frame updates**
+   - Implement `useRobotAnimation` hook in `src/scene/robots/useRobotAnimation.ts` that consumes runtime frame snapshots.
+   - Replace `RobotActor` internals with composition of `RobotMesh` + `useRobotAnimation`.
+3. **Entity subscription**
+   - Implement `useRobotsForFrame` selector hooking into `useMatchRuntime` snapshot API to remove manual intervals.
+
+## Phase 6 – Regression Hardening
+1. **Expand automated tests**
+   - Write integration tests for `useMatchRuntime` (pause/resume, victory handling) and AI + combat modules.
+2. **Performance + visual checks**
+   - Update Playwright smoke test to toggle quality settings and validate HUD latency < 100ms per Spec 002.
+3. **Documentation & onboarding**
+   - Document new module boundaries in `/docs/runtime-architecture.md` and update existing quickstarts referencing old components.
+
+## Dependencies & Sequencing Notes
+- Land phases sequentially to minimize merge risk; avoid parallelizing phases 2–4 because they modify shared systems.
+- Maintain backward compatibility with existing tests after each phase; introduce feature flags if partial rewrites risk regressions.
+- Coordinate with QA to schedule performance validation after Phase 5 before shipping changes to main.


### PR DESCRIPTION
## Summary
- add a consolidated refactor plan that bridges tech-debt findings with specs 001-003
- outline detailed task breakdown to execute the core runtime refactor phases

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fdd3a0965c832ab05c1b4c6252d44f