### PR TITLE
Add weapon VFX, rocket AoE, and beam visuals

### DIFF
--- a/src/components/vfx/EffectVisual.tsx
+++ b/src/components/vfx/EffectVisual.tsx
@@ -1,0 +1,114 @@
+import { Sparkles } from '@react-three/drei';
+
+import { EffectEntity } from '../../ecs/world';
+
+interface EffectVisualProps {
+  effect: EffectEntity;
+  currentTimeMs: number;
+}
+
+function toPositionArray(effect: EffectEntity): [number, number, number] {
+  return [effect.position.x, effect.position.y, effect.position.z];
+}
+
+function ExplosionEffect({ effect, progress }: { effect: EffectEntity; progress: number }) {
+  const position = toPositionArray(effect);
+  const scale = effect.radius * (0.6 + 0.6 * progress);
+  const fade = Math.max(0, 1 - progress);
+
+  return (
+    <>
+      <group position={position} scale={[scale, scale, scale]}>
+        <mesh>
+          <sphereGeometry args={[1, 16, 16]} />
+          <meshStandardMaterial
+            color={effect.color}
+            emissive={effect.color}
+            emissiveIntensity={1.4}
+            transparent
+            opacity={0.55 * fade}
+          />
+        </mesh>
+        <mesh scale={0.55}>
+          <sphereGeometry args={[1, 12, 12]} />
+          <meshStandardMaterial
+            color={effect.secondaryColor ?? '#fff4d6'}
+            emissive={effect.secondaryColor ?? '#fff4d6'}
+            emissiveIntensity={1.0}
+            transparent
+            opacity={0.45 * fade}
+          />
+        </mesh>
+      </group>
+      <Sparkles
+        position={position}
+        count={24}
+        speed={1.2}
+        size={effect.radius * 3}
+        scale={effect.radius * 2.2}
+        color={effect.secondaryColor ?? effect.color}
+      />
+    </>
+  );
+}
+
+function ImpactEffect({ effect, progress }: { effect: EffectEntity; progress: number }) {
+  const position = toPositionArray(effect);
+  const scale = effect.radius * (0.7 + 0.4 * progress);
+  const fade = Math.max(0, 1 - progress);
+
+  return (
+    <group position={position} scale={[scale, scale, scale]}>
+      <mesh>
+        <sphereGeometry args={[1, 12, 12]} />
+        <meshStandardMaterial
+          color={effect.color}
+          emissive={effect.color}
+          emissiveIntensity={1.0}
+          transparent
+          opacity={0.5 * fade}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+function LaserImpactEffect({ effect, progress }: { effect: EffectEntity; progress: number }) {
+  const position = toPositionArray(effect);
+  const scale = effect.radius * (0.5 + 0.6 * progress);
+  const fade = Math.max(0, 1 - progress);
+
+  return (
+    <group position={position} rotation={[-Math.PI / 2, 0, 0]}>
+      <mesh scale={[scale, scale, scale]}>
+        <ringGeometry args={[0.4, 0.8, 24]} />
+        <meshBasicMaterial color={effect.color} transparent opacity={0.5 * fade} />
+      </mesh>
+      <mesh position={[0, 0, effect.radius * 0.1]} scale={scale * 0.45}>
+        <sphereGeometry args={[1, 10, 10]} />
+        <meshStandardMaterial
+          color={effect.secondaryColor ?? '#c9ffff'}
+          emissive={effect.color}
+          emissiveIntensity={1.2}
+          transparent
+          opacity={0.5 * fade}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+export function EffectVisual({ effect, currentTimeMs }: EffectVisualProps) {
+  const elapsed = Math.max(0, currentTimeMs - effect.createdAt);
+  const progress = effect.duration > 0 ? Math.min(1, elapsed / effect.duration) : 1;
+
+  if (effect.effectType === 'explosion') {
+    return <ExplosionEffect effect={effect} progress={progress} />;
+  }
+
+  if (effect.effectType === 'laser-impact') {
+    return <LaserImpactEffect effect={effect} progress={progress} />;
+  }
+
+  return <ImpactEffect effect={effect} progress={progress} />;
+}

--- a/src/components/vfx/ProjectileVisual.tsx
+++ b/src/components/vfx/ProjectileVisual.tsx
@@ -1,0 +1,144 @@
+import { Line, Sparkles, Trail } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { useMemo, useRef } from 'react';
+import { Group, Vector3 } from 'three';
+
+import { ProjectileEntity, RobotEntity } from '../../ecs/world';
+
+interface ProjectileVisualProps {
+  projectile: ProjectileEntity;
+  shooter?: RobotEntity;
+  target?: RobotEntity;
+}
+
+function RocketProjectileVisual({ projectile }: { projectile: ProjectileEntity }) {
+  const groupRef = useRef<Group>(null);
+  const position = useMemo(() => new Vector3(), []);
+  const lookAtTarget = useMemo(() => new Vector3(), []);
+  const velocity = useMemo(() => new Vector3(), []);
+
+  useFrame(() => {
+    if (!groupRef.current) {
+      return;
+    }
+
+    position.set(projectile.position.x, projectile.position.y, projectile.position.z);
+    groupRef.current.position.copy(position);
+
+    velocity.set(projectile.velocity.x, projectile.velocity.y, projectile.velocity.z);
+    if (velocity.lengthSq() > 1e-6) {
+      lookAtTarget.copy(position).add(velocity);
+      groupRef.current.lookAt(lookAtTarget);
+    }
+  });
+
+  const radius = projectile.projectileSize ?? 0.32;
+  const trailColor = projectile.trailColor ?? '#ffb347';
+
+  return (
+    <Trail width={radius * 0.8} length={6} color={trailColor} attenuation={(t) => (1 - t) ** 2}>
+      <group ref={groupRef}>
+        <mesh rotation={[Math.PI / 2, 0, 0]}>
+          <cylinderGeometry args={[radius * 0.35, radius * 0.45, radius * 2, 12]} />
+          <meshStandardMaterial
+            color={projectile.projectileColor ?? '#ff955c'}
+            emissive={projectile.projectileColor ?? '#ff955c'}
+            emissiveIntensity={1.3}
+          />
+        </mesh>
+        <mesh position={[0, 0, radius * 1.1]} rotation={[Math.PI / 2, 0, 0]}>
+          <coneGeometry args={[radius * 0.55, radius * 1.1, 10]} />
+          <meshStandardMaterial color="#fff0d1" emissive="#ffd7a1" emissiveIntensity={1.1} />
+        </mesh>
+      </group>
+    </Trail>
+  );
+}
+
+function LaserProjectileVisual({
+  projectile,
+  shooter,
+  target,
+}: {
+  projectile: ProjectileEntity;
+  shooter?: RobotEntity;
+  target?: RobotEntity;
+}) {
+  const start: [number, number, number] = shooter
+    ? [shooter.position.x, shooter.position.y + 0.8, shooter.position.z]
+    : [projectile.position.x, projectile.position.y, projectile.position.z];
+  const hitPosition: [number, number, number] = target
+    ? [target.position.x, target.position.y + 0.8, target.position.z]
+    : [projectile.position.x, projectile.position.y, projectile.position.z];
+
+  const beamWidth = projectile.beamWidth ?? 0.08;
+  const color = projectile.projectileColor ?? '#7fffd4';
+
+  const points: [number, number, number][] = [start, hitPosition];
+
+  return (
+    <>
+      <Line points={points} color={color} lineWidth={beamWidth * 24} toneMapped={false} />
+      <mesh position={hitPosition}>
+        <sphereGeometry args={[beamWidth * 1.8, 12, 12]} />
+        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={1.8} />
+      </mesh>
+      <Sparkles
+        position={hitPosition}
+        count={14}
+        speed={1.6}
+        size={beamWidth * 18}
+        scale={beamWidth * 28}
+        color={color}
+      />
+    </>
+  );
+}
+
+function GunProjectileVisual({ projectile }: { projectile: ProjectileEntity }) {
+  const start: [number, number, number] = [
+    projectile.position.x,
+    projectile.position.y,
+    projectile.position.z,
+  ];
+  const direction = new Vector3(
+    projectile.velocity.x,
+    projectile.velocity.y,
+    projectile.velocity.z,
+  );
+  const length = direction.length() > 0 ? Math.min(1.4, Math.max(0.35, direction.length() * 0.04)) : 0.45;
+  if (direction.length() > 0) {
+    direction.normalize().multiplyScalar(length);
+  }
+  const end: [number, number, number] = [
+    start[0] - direction.x,
+    start[1] - direction.y,
+    start[2] - direction.z,
+  ];
+  const color = projectile.projectileColor ?? '#ffe08a';
+  const radius = Math.max(0.08, (projectile.projectileSize ?? 0.14) * 0.9);
+
+  const points: [number, number, number][] = [start, end];
+
+  return (
+    <>
+      <Line points={points} color={color} lineWidth={2} toneMapped={false} />
+      <mesh position={start}>
+        <sphereGeometry args={[radius, 10, 10]} />
+        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={1.1} />
+      </mesh>
+    </>
+  );
+}
+
+export function ProjectileVisual({ projectile, shooter, target }: ProjectileVisualProps) {
+  if (projectile.weapon === 'rocket') {
+    return <RocketProjectileVisual projectile={projectile} />;
+  }
+
+  if (projectile.weapon === 'laser') {
+    return <LaserProjectileVisual projectile={projectile} shooter={shooter} target={target} />;
+  }
+
+  return <GunProjectileVisual projectile={projectile} />;
+}

--- a/src/ecs/systems/combatSystem.ts
+++ b/src/ecs/systems/combatSystem.ts
@@ -50,6 +50,13 @@ function createProjectile(
     maxDistance: profile.range,
     speed: profile.projectileSpeed,
     targetId: target.id,
+    projectileSize: profile.projectileSize,
+    projectileColor: profile.projectileColor,
+    trailColor: profile.trailColor,
+    aoeRadius: profile.aoeRadius,
+    explosionDurationMs: profile.explosionDurationMs,
+    beamWidth: profile.beamWidth,
+    impactDurationMs: profile.impactDurationMs,
   };
 }
 

--- a/src/ecs/systems/effectSystem.ts
+++ b/src/ecs/systems/effectSystem.ts
@@ -1,0 +1,12 @@
+import { BattleWorld } from '../world';
+
+export function updateEffectSystem(world: BattleWorld): void {
+  const now = world.state.elapsedMs;
+  const effects = [...world.effects.entities];
+
+  effects.forEach((effect) => {
+    if (now - effect.createdAt >= effect.duration) {
+      world.world.remove(effect);
+    }
+  });
+}

--- a/src/runtime/simulation/battleRunner.ts
+++ b/src/runtime/simulation/battleRunner.ts
@@ -1,5 +1,6 @@
 import { updateAISystem } from '../../ecs/systems/aiSystem';
 import { updateCombatSystem } from '../../ecs/systems/combatSystem';
+import { updateEffectSystem } from '../../ecs/systems/effectSystem';
 import { updateMovementSystem } from '../../ecs/systems/movementSystem';
 import { updateProjectileSystem } from '../../ecs/systems/projectileSystem';
 import { spawnTeams } from '../../ecs/systems/spawnSystem';
@@ -83,6 +84,7 @@ export function createBattleRunner(
         updateCombatSystem(world, telemetry);
         updateMovementSystem(world, deltaSeconds);
         updateProjectileSystem(world, deltaSeconds, telemetry);
+        updateEffectSystem(world);
         evaluateVictory(world, matchMachine);
       }
 

--- a/src/simulation/combat/weapons.ts
+++ b/src/simulation/combat/weapons.ts
@@ -6,6 +6,13 @@ export interface WeaponProfile {
   fireRate: number;
   projectileSpeed: number;
   range: number;
+  projectileSize: number;
+  projectileColor: string;
+  trailColor?: string;
+  aoeRadius?: number;
+  explosionDurationMs?: number;
+  beamWidth?: number;
+  impactDurationMs?: number;
 }
 
 const WEAPON_PROFILES: Record<WeaponType, WeaponProfile> = {
@@ -15,6 +22,10 @@ const WEAPON_PROFILES: Record<WeaponType, WeaponProfile> = {
     fireRate: 1.8,
     projectileSpeed: 32,
     range: 28,
+    projectileSize: 0.18,
+    projectileColor: '#7fffd4',
+    beamWidth: 0.08,
+    impactDurationMs: 280,
   },
   gun: {
     type: 'gun',
@@ -22,6 +33,9 @@ const WEAPON_PROFILES: Record<WeaponType, WeaponProfile> = {
     fireRate: 1.4,
     projectileSpeed: 26,
     range: 24,
+    projectileSize: 0.14,
+    projectileColor: '#ffe08a',
+    impactDurationMs: 220,
   },
   rocket: {
     type: 'rocket',
@@ -29,23 +43,29 @@ const WEAPON_PROFILES: Record<WeaponType, WeaponProfile> = {
     fireRate: 0.9,
     projectileSpeed: 22,
     range: 34,
+    projectileSize: 0.32,
+    projectileColor: '#ff9d5c',
+    trailColor: '#ffbe76',
+    aoeRadius: 2.5,
+    explosionDurationMs: 720,
+    impactDurationMs: 360,
   },
 };
 
 const DAMAGE_MATRIX: Record<WeaponType, Record<WeaponType, number>> = {
   laser: {
     laser: 1,
-    gun: 1.35,
-    rocket: 0.75,
+    gun: 1.25,
+    rocket: 0.85,
   },
   gun: {
-    laser: 0.75,
+    laser: 0.85,
     gun: 1,
-    rocket: 1.35,
+    rocket: 1.25,
   },
   rocket: {
-    laser: 1.35,
-    gun: 0.75,
+    laser: 1.25,
+    gun: 0.85,
     rocket: 1,
   },
 };


### PR DESCRIPTION
## Summary
- extend weapon profiles with visual metadata and updated rock-paper-scissors multipliers
- add rocket area damage, spawn short-lived effect entities, and clean them via a dedicated system
- render custom rocket trails, laser beams, gun tracers, and explosion/impact VFX inside the simulation scene

## Testing
- npm run lint
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918846be9e0832abbfc0226d320c33e)