### PR TITLE
Add keyboard shortcuts for Pause and Reset

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Keyboard Shortcuts
+**Learning:** Adding keyboard shortcuts (Space/R) significantly improves the testing loop for simulation games, but must handle key repeats and input focus to avoid UI conflicts.
+**Action:** Always check `!e.repeat` for toggle actions and `e.target` for inputs when implementing global shortcuts.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,6 +150,32 @@ export default function App() {
     runnerRef.current?.reset();
   }, []);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isSettingsOpen) return;
+      if (e.repeat) return;
+
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      if (e.key === " " || e.code === "Space") {
+        e.preventDefault();
+        handlePauseResume();
+      } else if (e.key === "r" || e.key === "R") {
+        handleReset();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isSettingsOpen, handlePauseResume, handleReset]);
+
   const statusText = formatStatus(matchSnapshot);
   const pauseLabel = matchSnapshot.phase === "paused" ? "Resume" : "Pause";
 
@@ -281,10 +307,14 @@ export default function App() {
           gap: 12,
         }}
       >
-        <button type="button" onClick={handlePauseResume}>
+        <button
+          type="button"
+          onClick={handlePauseResume}
+          title="Pause/Resume (Space)"
+        >
           {pauseLabel}
         </button>
-        <button type="button" onClick={handleReset}>
+        <button type="button" onClick={handleReset} title="Reset (R)">
           Reset
         </button>
       </div>

--- a/tests/ui/AppShortcuts.test.tsx
+++ b/tests/ui/AppShortcuts.test.tsx
@@ -1,0 +1,166 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import App from '@/App';
+import * as worldModule from '@/ecs/world';
+import * as machineModule from '@/runtime/state/matchStateMachine';
+import * as telemetryModule from '@/runtime/simulation/telemetryAdapter';
+
+// Hoist the mock function so it can be used in the mock factory
+const { mockRunnerReset } = vi.hoisted(() => ({
+  mockRunnerReset: vi.fn(),
+}));
+
+// Mock Simulation component as it uses Canvas
+vi.mock('@/components/Simulation', () => ({
+  Simulation: ({ onRunnerReady }: { onRunnerReady: (runner: any) => void }) => {
+    // Simulate the runner being ready immediately
+    onRunnerReady({ reset: mockRunnerReset });
+    return <div data-testid="simulation-mock" />;
+  },
+}));
+
+// Mock other sub-components to avoid complexity
+vi.mock('@/components/debug/ObstacleEditor', () => ({ ObstacleEditor: () => null }));
+vi.mock('@/components/debug/ObstacleSpawner', () => ({ ObstacleSpawner: () => null }));
+vi.mock('@/components/debug/PerfToggles', () => ({ PerfToggles: () => null }));
+vi.mock('@/components/ui/SettingsModal', () => ({
+  SettingsModal: ({ isOpen }: { isOpen: boolean }) => (
+    isOpen ? <div data-testid="settings-modal" /> : null
+  ),
+}));
+
+describe('App Keyboard Shortcuts', () => {
+  let mockPause: ReturnType<typeof vi.fn>;
+  let mockResume: ReturnType<typeof vi.fn>;
+  let mockReset: ReturnType<typeof vi.fn>;
+  let mockGetSnapshot: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Reset the hoisted mock
+    mockRunnerReset.mockClear();
+
+    // Mock createBattleWorld
+    vi.spyOn(worldModule, 'createBattleWorld').mockReturnValue({
+      robots: { entities: [] },
+      world: { add: vi.fn(), remove: vi.fn() },
+      obstacles: { entities: [] },
+    } as any);
+
+    // Mock createTelemetryPort
+    vi.spyOn(telemetryModule, 'createTelemetryPort').mockReturnValue({} as any);
+
+    // Mock createMatchStateMachine
+    mockPause = vi.fn();
+    mockResume = vi.fn();
+    mockReset = vi.fn(); // This is the machine reset, which might not be called directly
+    mockGetSnapshot = vi.fn().mockReturnValue({
+      phase: 'running',
+      elapsedMs: 0,
+      restartTimerMs: null,
+      winner: null,
+    });
+
+    vi.spyOn(machineModule, 'createMatchStateMachine').mockReturnValue({
+      start: vi.fn(),
+      pause: mockPause as any,
+      resume: mockResume as any,
+      reset: mockReset as any,
+      declareVictory: vi.fn(),
+      tick: vi.fn(),
+      getSnapshot: mockGetSnapshot as any,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('triggers pause when Space is pressed while running', () => {
+    mockGetSnapshot.mockReturnValue({ phase: 'running', elapsedMs: 0, restartTimerMs: null, winner: null });
+    render(<App />);
+
+    fireEvent.keyDown(window, { key: ' ' });
+
+    expect(mockPause).toHaveBeenCalled();
+  });
+
+  it('triggers resume when Space is pressed while paused', () => {
+    mockGetSnapshot.mockReturnValue({ phase: 'paused', elapsedMs: 0, restartTimerMs: null, winner: null });
+    render(<App />);
+
+    fireEvent.keyDown(window, { key: ' ' });
+
+    expect(mockResume).toHaveBeenCalled();
+  });
+
+  it('triggers reset when R is pressed', () => {
+    render(<App />);
+
+    fireEvent.keyDown(window, { key: 'r' });
+
+    expect(mockRunnerReset).toHaveBeenCalled();
+  });
+
+  it('triggers reset when R is pressed (upper case)', () => {
+    render(<App />);
+
+    fireEvent.keyDown(window, { key: 'R' });
+
+    expect(mockRunnerReset).toHaveBeenCalled();
+  });
+
+  it('ignores repeated keydown events (key hold)', () => {
+    mockGetSnapshot.mockReturnValue({
+      phase: 'running',
+      elapsedMs: 0,
+      restartTimerMs: null,
+      winner: null,
+    });
+    render(<App />);
+
+    fireEvent.keyDown(window, { key: ' ', repeat: true });
+
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger shortcuts when typing in an input', () => {
+    mockGetSnapshot.mockReturnValue({
+      phase: 'running',
+      elapsedMs: 0,
+      restartTimerMs: null,
+      winner: null,
+    });
+    render(
+      <div>
+        <App />
+        <input data-testid="test-input" />
+      </div>
+    );
+
+    const input = screen.getByTestId('test-input');
+    input.focus();
+
+    // Fire event on the input, which bubbles to window
+    fireEvent.keyDown(input, { key: ' ', bubbles: true });
+
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger shortcuts when SettingsModal is open', () => {
+    render(<App />);
+
+    // Open settings
+    const settingsButton = screen.getByLabelText('Open settings');
+    fireEvent.click(settingsButton);
+
+    // Check if modal is open (mocked component)
+    expect(screen.getByTestId('settings-modal')).toBeDefined();
+
+    // Try shortcuts
+    fireEvent.keyDown(window, { key: ' ' });
+    fireEvent.keyDown(window, { key: 'r' });
+
+    expect(mockPause).not.toHaveBeenCalled();
+    expect(mockRunnerReset).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Introduce keyboard shortcuts for pausing and resetting the simulation, enhancing user experience during gameplay. Implement checks to prevent conflicts with input fields and handle key repeat events effectively. Add corresponding tests to ensure functionality.

