### PR TITLE
Refactor InstancedProjectiles for improved maintainability

### DIFF
--- a/src/components/vfx/InstancedProjectileGroup.tsx
+++ b/src/components/vfx/InstancedProjectileGroup.tsx
@@ -1,0 +1,192 @@
+import { useFrame } from "@react-three/fiber";
+import { useEffect, useMemo } from "react";
+import { AdditiveBlending, BufferGeometry, Color, InstancedMesh, Object3D, Vector3 } from "three";
+
+import { ProjectileEntity } from "../../ecs/world";
+import { perfMarkEnd, perfMarkStart } from "../../lib/perf";
+import { hideAllInstances, normalizeHDRForInstance } from "../../visuals/instanceColorUtils";
+import { VisualInstanceManager } from "../../visuals/VisualInstanceManager";
+import { markMaterialNeedsUpdate, useInstancedMeshLifecycle } from "./useInstancedMeshLifecycle";
+
+export interface InstancedProjectileGroupProps {
+  projectiles: ProjectileEntity[];
+  instanceManager: VisualInstanceManager;
+  category: "bullets" | "rockets";
+  geometry: BufferGeometry;
+  baseColorHex: string;
+  intensity: number;
+  updateInstance: (
+    projectile: ProjectileEntity,
+    dummy: Object3D,
+    speed: number
+  ) => void;
+  isMatch: (projectile: ProjectileEntity) => boolean;
+}
+
+export function InstancedProjectileGroup({
+  projectiles,
+  instanceManager,
+  category,
+  geometry,
+  baseColorHex,
+  intensity,
+  updateInstance,
+  isMatch,
+}: InstancedProjectileGroupProps) {
+  const capacity = instanceManager.getCapacity(category);
+  const { meshRef, activeRef, previousActiveRef, dirtyRef, initStateRef } =
+    useInstancedMeshLifecycle(capacity);
+
+  // Expose refs for end-to-end debug inspection (Playwright / devtools)
+  useEffect(() => {
+    // Avoid using `any` in lint rules while still allowing debug plumbing.
+    const win = window as unknown as {
+      __instancedRefs?: Record<string, InstancedMesh | null>;
+    };
+    win.__instancedRefs = win.__instancedRefs || {};
+    win.__instancedRefs[category] = meshRef.current;
+  }, [category, meshRef]);
+
+  const dummy = useMemo(() => new Object3D(), []);
+  const velocity = useMemo(() => new Vector3(), []);
+  const upVector = useMemo(() => new Vector3(0, 1, 0), []);
+  const color = useMemo(() => new Color(), []);
+  const hiddenColor = useMemo(() => new Color("#000000"), []);
+
+  useFrame(() => {
+    perfMarkStart(`InstancedProjectileGroup.${category}`);
+    const mesh = meshRef.current;
+    if (!mesh || capacity === 0) {
+      perfMarkEnd(`InstancedProjectileGroup.${category}`);
+      return;
+    }
+
+    // Initialize all instance slots to a hidden offscreen matrix and black color
+    // This is a safety check in useFrame in case layout effect missed it or context was lost?
+    // Following original pattern.
+    if (
+      !initStateRef.current.ready &&
+      initStateRef.current.capacity === capacity
+    ) {
+      const hadInstanceColor = Boolean(mesh.instanceColor);
+      hideAllInstances(mesh, capacity);
+      if (!hadInstanceColor && mesh.instanceColor) {
+        markMaterialNeedsUpdate(mesh.material);
+      }
+      initStateRef.current.ready = true;
+    }
+
+    const currentActive = activeRef.current;
+    const lastActive = previousActiveRef.current;
+    const currentDirty = dirtyRef.current;
+
+    currentActive.clear();
+    currentDirty.clear();
+
+    let matrixDirty = false;
+    let colorsDirty = false;
+
+    for (let i = 0; i < projectiles.length; i += 1) {
+      const projectile = projectiles[i];
+      if (!isMatch(projectile)) {
+        continue;
+      }
+
+      const index =
+        projectile.instanceIndex ??
+        instanceManager.getIndex(category, projectile.id);
+      if (index === null || index === undefined || index >= capacity) {
+        continue;
+      }
+
+      currentActive.add(index);
+
+      dummy.position.set(
+        projectile.position.x,
+        projectile.position.y,
+        projectile.position.z,
+      );
+      velocity.set(
+        projectile.velocity.x,
+        projectile.velocity.y,
+        projectile.velocity.z,
+      );
+      const speed = velocity.length();
+
+      if (speed > 1e-6) {
+        velocity.normalize();
+        dummy.quaternion.setFromUnitVectors(upVector, velocity);
+      } else {
+        dummy.quaternion.identity();
+      }
+
+      updateInstance(projectile, dummy, speed);
+
+      dummy.updateMatrix();
+      mesh.setMatrixAt(index, dummy.matrix);
+      matrixDirty = true;
+
+      const colorHex = projectile.projectileColor ?? baseColorHex;
+      // Boost intensity so projectiles read well under postprocessing.
+      color.set(colorHex).multiplyScalar(intensity);
+      // Normalize HDR values for display: clamp peaks + Reinhard tone mapping.
+      normalizeHDRForInstance(color, { exposure: 1.0, maxChannel: 3.0 });
+      mesh.setColorAt(index, color);
+      colorsDirty = true;
+
+      currentDirty.add(index);
+    }
+
+    // Handle deactivation
+    for (const index of lastActive) {
+      if (!currentActive.has(index)) {
+        dummy.position.set(0, -512, 0);
+        dummy.rotation.set(0, 0, 0);
+        dummy.scale.set(0.001, 0.001, 0.001);
+        dummy.updateMatrix();
+        mesh.setMatrixAt(index, dummy.matrix);
+        mesh.setColorAt(index, hiddenColor);
+        currentDirty.add(index);
+        matrixDirty = true;
+        colorsDirty = true;
+      }
+    }
+
+    if (currentDirty.size > 0 || matrixDirty || colorsDirty) {
+      mesh.instanceMatrix.needsUpdate = true;
+      if (mesh.instanceColor) {
+        mesh.instanceColor.needsUpdate = true;
+      }
+    }
+
+    // Swap refs
+    previousActiveRef.current = currentActive;
+    activeRef.current = lastActive;
+
+    perfMarkEnd(`InstancedProjectileGroup.${category}`);
+  });
+
+  if (capacity <= 0) {
+    return null;
+  }
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, capacity]}
+      frustumCulled={false}
+      name={`instanced-${category}`}
+    >
+      <primitive object={geometry} attach="geometry" />
+      <meshBasicMaterial
+        color="#ffffff"
+        toneMapped={false}
+        transparent
+        opacity={0.95}
+        blending={AdditiveBlending}
+        depthWrite={false}
+        vertexColors
+      />
+    </instancedMesh>
+  );
+}

--- a/src/components/vfx/InstancedProjectiles.tsx
+++ b/src/components/vfx/InstancedProjectiles.tsx
@@ -1,36 +1,14 @@
-import { useFrame } from "@react-three/fiber";
-import { MutableRefObject, useEffect, useLayoutEffect, useMemo, useRef } from "react";
-import { AdditiveBlending, Color, CylinderGeometry, InstancedMesh, Material, Object3D, Vector3 } from "three";
+import { useEffect, useMemo } from "react";
+import { CylinderGeometry, Object3D } from "three";
 
 import { ProjectileEntity } from "../../ecs/world";
-import { perfMarkEnd, perfMarkStart } from "../../lib/perf";
-import { ensureGeometryHasVertexColors, hideAllInstances, normalizeHDRForInstance } from "../../visuals/instanceColorUtils";
+import { ensureGeometryHasVertexColors } from "../../visuals/instanceColorUtils";
 import { VisualInstanceManager } from "../../visuals/VisualInstanceManager";
+import { InstancedProjectileGroup } from "./InstancedProjectileGroup";
 
 interface InstancedProjectilesProps {
   projectiles: ProjectileEntity[];
   instanceManager: VisualInstanceManager;
-}
-
-function markMaterialNeedsUpdate(material: Material | Material[]) {
-  if (Array.isArray(material)) {
-    for (let i = 0; i < material.length; i += 1) {
-      material[i].needsUpdate = true;
-    }
-    return;
-  }
-  material.needsUpdate = true;
-}
-
-function useResizeInstanceCount(
-  ref: MutableRefObject<InstancedMesh | null>,
-  capacity: number,
-) {
-  useLayoutEffect(() => {
-    if (ref.current) {
-      ref.current.count = capacity;
-    }
-  }, [capacity, ref]);
 }
 
 /**
@@ -41,28 +19,6 @@ export function InstancedProjectiles({
   projectiles,
   instanceManager,
 }: InstancedProjectilesProps) {
-  const bulletCapacity = instanceManager.getCapacity("bullets");
-  const rocketCapacity = instanceManager.getCapacity("rockets");
-  const shouldRenderBullets = bulletCapacity > 0;
-  const shouldRenderRockets = rocketCapacity > 0;
-
-  const bulletMeshRef = useRef<InstancedMesh | null>(null);
-  const rocketMeshRef = useRef<InstancedMesh | null>(null);
-
-  // Expose refs for end-to-end debug inspection (Playwright / devtools)
-  useEffect(() => {
-    // Avoid using `any` in lint rules while still allowing debug plumbing.
-    const win = (window as unknown) as { __instancedRefs?: Record<string, InstancedMesh | null> };
-    win.__instancedRefs = win.__instancedRefs || {};
-    win.__instancedRefs.bullets = bulletMeshRef.current;
-    win.__instancedRefs.rockets = rocketMeshRef.current;
-  }, [bulletMeshRef, rocketMeshRef]);
-  const dummy = useMemo(() => new Object3D(), []);
-  const velocity = useMemo(() => new Vector3(), []);
-  const upVector = useMemo(() => new Vector3(0, 1, 0), []);
-  const color = useMemo(() => new Color(), []);
-  const hiddenColor = useMemo(() => new Color("#000000"), []);
-
   const bulletGeometry = useMemo(() => {
     const geometry = new CylinderGeometry(1, 1, 1, 10);
     ensureGeometryHasVertexColors(geometry);
@@ -81,294 +37,58 @@ export function InstancedProjectiles({
       rocketGeometry.dispose();
     };
   }, [bulletGeometry, rocketGeometry]);
-  const bulletActiveRef = useRef<Set<number>>(new Set());
-  const rocketActiveRef = useRef<Set<number>>(new Set());
-  const previousBulletActiveRef = useRef<Set<number>>(new Set());
-  const previousRocketActiveRef = useRef<Set<number>>(new Set());
-  const bulletDirtyRef = useRef<Set<number>>(new Set());
-  const rocketDirtyRef = useRef<Set<number>>(new Set());
-  const bulletInitStateRef = useRef({ capacity: -1, ready: false });
-  const rocketInitStateRef = useRef({ capacity: -1, ready: false });
 
-  useResizeInstanceCount(bulletMeshRef, bulletCapacity);
-  useResizeInstanceCount(rocketMeshRef, rocketCapacity);
+  const updateBulletInstance = (
+    projectile: ProjectileEntity,
+    dummy: Object3D,
+    speed: number,
+  ) => {
+    const scale = Math.max(0.05, projectile.projectileSize ?? 0.14);
+    const length = Math.min(1.4, Math.max(0.35, speed * 0.04));
+    const thickness = Math.max(0.06, scale * 0.55);
+    dummy.scale.set(thickness, length, thickness);
+  };
 
-  useLayoutEffect(() => {
-    bulletInitStateRef.current = { capacity: bulletCapacity, ready: false };
-  }, [bulletCapacity]);
+  const updateRocketInstance = (
+    projectile: ProjectileEntity,
+    dummy: Object3D,
+    _speed: number,
+  ) => {
+    // `_speed` intentionally unused for rockets; keep param for signature compatibility
+    // and use a no-op reference to satisfy lint rules.
+    void _speed;
 
-  useLayoutEffect(() => {
-    rocketInitStateRef.current = { capacity: rocketCapacity, ready: false };
-  }, [rocketCapacity]);
+    const scale = Math.max(0.05, projectile.projectileSize ?? 0.14);
+    const thickness = Math.max(0.08, scale * 0.55);
+    dummy.scale.set(thickness, scale * 2.8, thickness);
+  };
 
-  useLayoutEffect(() => {
-    const mesh = bulletMeshRef.current;
-    if (!mesh || bulletCapacity <= 0) return;
-
-    const hadInstanceColor = Boolean(mesh.instanceColor);
-    hideAllInstances(mesh, bulletCapacity);
-    bulletInitStateRef.current = { capacity: bulletCapacity, ready: true };
-
-    // If instanceColor didn't exist during the first shader compile, Three won't
-    // enable instancing colors until the material is recompiled.
-    if (!hadInstanceColor && mesh.instanceColor) {
-      markMaterialNeedsUpdate(mesh.material);
-    }
-  }, [bulletCapacity]);
-
-  useLayoutEffect(() => {
-    const mesh = rocketMeshRef.current;
-    if (!mesh || rocketCapacity <= 0) return;
-
-    const hadInstanceColor = Boolean(mesh.instanceColor);
-    hideAllInstances(mesh, rocketCapacity);
-    rocketInitStateRef.current = { capacity: rocketCapacity, ready: true };
-
-    if (!hadInstanceColor && mesh.instanceColor) {
-      markMaterialNeedsUpdate(mesh.material);
-    }
-  }, [rocketCapacity]);
-
-  useFrame(() => {
-    perfMarkStart("InstancedProjectiles.useFrame");
-    const bulletMesh = bulletMeshRef.current;
-    const rocketMesh = rocketMeshRef.current;
-    if (!bulletMesh && !rocketMesh) {
-      perfMarkEnd("InstancedProjectiles.useFrame");
-      return;
-    }
-
-    // Initialize all instance slots to a hidden offscreen matrix and black color
-    if (
-      bulletMesh &&
-      bulletInitStateRef.current.ready === false &&
-      bulletInitStateRef.current.capacity === bulletCapacity
-    ) {
-      const hadInstanceColor = Boolean(bulletMesh.instanceColor);
-      hideAllInstances(bulletMesh, bulletCapacity);
-      if (!hadInstanceColor && bulletMesh.instanceColor) {
-        markMaterialNeedsUpdate(bulletMesh.material);
-      }
-      bulletInitStateRef.current.ready = true;
-    }
-
-    if (
-      rocketMesh &&
-      rocketInitStateRef.current.ready === false &&
-      rocketInitStateRef.current.capacity === rocketCapacity
-    ) {
-      const hadInstanceColor = Boolean(rocketMesh.instanceColor);
-      hideAllInstances(rocketMesh, rocketCapacity);
-      if (!hadInstanceColor && rocketMesh.instanceColor) {
-        markMaterialNeedsUpdate(rocketMesh.material);
-      }
-      rocketInitStateRef.current.ready = true;
-    }
-
-    const currentBulletActive = bulletActiveRef.current;
-    const currentRocketActive = rocketActiveRef.current;
-    const lastBulletActive = previousBulletActiveRef.current;
-    const lastRocketActive = previousRocketActiveRef.current;
-    const currentBulletDirty = bulletDirtyRef.current;
-    const currentRocketDirty = rocketDirtyRef.current;
-
-    currentBulletActive.clear();
-    currentRocketActive.clear();
-    currentBulletDirty.clear();
-    currentRocketDirty.clear();
-
-    // Track whether we wrote instance matrices/colors this frame (so we can
-    // mark instanceMatrix/instanceColor.needsUpdate reliably even if the
-    // deactivation path isn't hit).
-    let bulletColorsDirty = false;
-    let rocketColorsDirty = false;
-    let bulletMatrixDirty = false;
-    let rocketMatrixDirty = false;
-
-    for (let i = 0; i < projectiles.length; i += 1) {
-      const projectile = projectiles[i];
-      if (projectile.weapon === "laser") {
-        continue;
-      }
-
-      const category = projectile.weapon === "rocket" ? "rockets" : "bullets";
-      const mesh = category === "rockets" ? rocketMesh : bulletMesh;
-      if (!mesh) {
-        continue;
-      }
-
-      const capacity = category === "rockets" ? rocketCapacity : bulletCapacity;
-      if (capacity === 0) {
-        continue;
-      }
-
-      const index =
-        projectile.instanceIndex ??
-        instanceManager.getIndex(category, projectile.id);
-      if (index === null || index === undefined || index >= capacity) {
-        continue;
-      }
-
-      const seen =
-        category === "rockets" ? currentRocketActive : currentBulletActive;
-      const dirty =
-        category === "rockets" ? currentRocketDirty : currentBulletDirty;
-      seen.add(index);
-
-      dummy.position.set(
-        projectile.position.x,
-        projectile.position.y,
-        projectile.position.z,
-      );
-      const scale = Math.max(0.05, projectile.projectileSize ?? 0.14);
-      velocity.set(
-        projectile.velocity.x,
-        projectile.velocity.y,
-        projectile.velocity.z,
-      );
-      const speed = velocity.length();
-      if (speed > 1e-6) {
-        velocity.normalize();
-        dummy.quaternion.setFromUnitVectors(upVector, velocity);
-      } else {
-        dummy.quaternion.identity();
-      }
-
-      if (category === "rockets") {
-        const thickness = Math.max(0.08, scale * 0.55);
-        dummy.scale.set(thickness, scale * 2.8, thickness);
-      } else {
-        const length = Math.min(1.4, Math.max(0.35, speed * 0.04));
-        const thickness = Math.max(0.06, scale * 0.55);
-        dummy.scale.set(thickness, length, thickness);
-      }
-
-      dummy.updateMatrix();
-      mesh.setMatrixAt(index, dummy.matrix);
-
-      // Mark matrix dirty for this category
-      if (category === "rockets") {
-        rocketMatrixDirty = true;
-      } else {
-        bulletMatrixDirty = true;
-      }
-
-      const colorHex =
-        projectile.projectileColor ??
-        (category === "rockets" ? "#ff955c" : "#ffe08a");
-      // Boost intensity so projectiles read well under postprocessing.
-      color.set(colorHex).multiplyScalar(category === "rockets" ? 3.0 : 3.6);
-      // Normalize HDR values for display: clamp peaks + Reinhard tone mapping.
-      normalizeHDRForInstance(color, { exposure: 1.0, maxChannel: 3.0 });
-      mesh.setColorAt(index, color);
-
-      // Mark color dirty for this category
-      if (category === "rockets") {
-        rocketColorsDirty = true;
-      } else {
-        bulletColorsDirty = true;
-      }
-
-      dirty.add(index);
-    }
-
-    if (bulletMesh) {
-      for (const index of lastBulletActive) {
-        if (!currentBulletActive.has(index)) {
-          dummy.position.set(0, -512, 0);
-          dummy.rotation.set(0, 0, 0);
-          dummy.scale.set(0.001, 0.001, 0.001);
-          dummy.updateMatrix();
-          bulletMesh.setMatrixAt(index, dummy.matrix);
-          bulletMesh.setColorAt(index, hiddenColor);
-          currentBulletDirty.add(index);
-        }
-      }
-
-      if (currentBulletDirty.size > 0 || bulletMatrixDirty || bulletColorsDirty) {
-        bulletMesh.instanceMatrix.needsUpdate = true;
-        if (bulletMesh.instanceColor) {
-          bulletMesh.instanceColor.needsUpdate = true;
-        }
-      }
-    }
-
-    if (rocketMesh) {
-      for (const index of lastRocketActive) {
-        if (!currentRocketActive.has(index)) {
-          dummy.position.set(0, -512, 0);
-          dummy.rotation.set(0, 0, 0);
-          dummy.scale.set(0.001, 0.001, 0.001);
-          dummy.updateMatrix();
-          rocketMesh.setMatrixAt(index, dummy.matrix);
-          rocketMesh.setColorAt(index, hiddenColor);
-          currentRocketDirty.add(index);
-          // mark that we modified matrices/colors via deactivation path
-          rocketMatrixDirty = true;
-          rocketColorsDirty = true;
-        }
-      }
-
-      if (currentRocketDirty.size > 0 || rocketMatrixDirty || rocketColorsDirty) {
-        rocketMesh.instanceMatrix.needsUpdate = true;
-        if (rocketMesh.instanceColor) {
-          rocketMesh.instanceColor.needsUpdate = true;
-        }
-      }
-    }
-
-    previousBulletActiveRef.current = currentBulletActive;
-    bulletActiveRef.current = lastBulletActive;
-
-    previousRocketActiveRef.current = currentRocketActive;
-    rocketActiveRef.current = lastRocketActive;
-
-    perfMarkEnd("InstancedProjectiles.useFrame");
-  });
-
-  if (!shouldRenderBullets && !shouldRenderRockets) {
-    return null;
-  }
+  const isBullet = (p: ProjectileEntity) =>
+    p.weapon !== "laser" && p.weapon !== "rocket";
+  const isRocket = (p: ProjectileEntity) => p.weapon === "rocket";
 
   return (
     <group>
-      {shouldRenderBullets ? (
-        <instancedMesh
-          name="instanced-bullets"
-          ref={bulletMeshRef}
-          args={[undefined, undefined, bulletCapacity]}
-          frustumCulled={false}
-        >
-          <primitive object={bulletGeometry} attach="geometry" />
-          <meshBasicMaterial
-            color="#ffffff"
-            toneMapped={false}
-            transparent
-            opacity={0.95}
-            blending={AdditiveBlending}
-            depthWrite={false}
-            vertexColors
-          />
-        </instancedMesh>
-      ) : null}
-      {shouldRenderRockets ? (
-        <instancedMesh
-          ref={rocketMeshRef}
-          args={[undefined, undefined, rocketCapacity]}
-          frustumCulled={false}
-        >
-          <primitive object={rocketGeometry} attach="geometry" />
-          <meshBasicMaterial
-            color="#ffffff"
-            toneMapped={false}
-            transparent
-            opacity={0.95}
-            blending={AdditiveBlending}
-            depthWrite={false}
-            vertexColors
-          />
-        </instancedMesh>
-      ) : null}
+      <InstancedProjectileGroup
+        projectiles={projectiles}
+        instanceManager={instanceManager}
+        category="bullets"
+        geometry={bulletGeometry}
+        baseColorHex="#ffe08a"
+        intensity={3.6}
+        updateInstance={updateBulletInstance}
+        isMatch={isBullet}
+      />
+      <InstancedProjectileGroup
+        projectiles={projectiles}
+        instanceManager={instanceManager}
+        category="rockets"
+        geometry={rocketGeometry}
+        baseColorHex="#ff955c"
+        intensity={3.0}
+        updateInstance={updateRocketInstance}
+        isMatch={isRocket}
+      />
     </group>
   );
 }

--- a/src/components/vfx/useInstancedMeshLifecycle.ts
+++ b/src/components/vfx/useInstancedMeshLifecycle.ts
@@ -1,0 +1,61 @@
+import { MutableRefObject, useLayoutEffect, useRef } from "react";
+import { InstancedMesh, Material } from "three";
+
+import { hideAllInstances } from "../../visuals/instanceColorUtils";
+
+export function markMaterialNeedsUpdate(material: Material | Material[]) {
+  if (Array.isArray(material)) {
+    for (let i = 0; i < material.length; i += 1) {
+      material[i].needsUpdate = true;
+    }
+    return;
+  }
+  material.needsUpdate = true;
+}
+
+function useResizeInstanceCount(
+  ref: MutableRefObject<InstancedMesh | null>,
+  capacity: number,
+) {
+  useLayoutEffect(() => {
+    if (ref.current) {
+      ref.current.count = capacity;
+    }
+  }, [capacity, ref]);
+}
+
+export function useInstancedMeshLifecycle(capacity: number) {
+  const meshRef = useRef<InstancedMesh | null>(null);
+  const activeRef = useRef<Set<number>>(new Set());
+  const previousActiveRef = useRef<Set<number>>(new Set());
+  const dirtyRef = useRef<Set<number>>(new Set());
+  const initStateRef = useRef({ capacity: -1, ready: false });
+
+  useResizeInstanceCount(meshRef, capacity);
+
+  useLayoutEffect(() => {
+    initStateRef.current = { capacity, ready: false };
+  }, [capacity]);
+
+  // Initial hiding when capacity changes
+  useLayoutEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh || capacity <= 0) return;
+
+    const hadInstanceColor = Boolean(mesh.instanceColor);
+    hideAllInstances(mesh, capacity);
+    initStateRef.current = { capacity, ready: true };
+
+    if (!hadInstanceColor && mesh.instanceColor) {
+      markMaterialNeedsUpdate(mesh.material);
+    }
+  }, [capacity]);
+
+  return {
+    meshRef,
+    activeRef,
+    previousActiveRef,
+    dirtyRef,
+    initStateRef,
+  };
+}


### PR DESCRIPTION
Refactor InstancedProjectiles to utilize reusable hooks and components, enhancing code maintainability and separation of concerns. Introduce `useInstancedMeshLifecycle` for managing instanced mesh state and create `InstancedProjectileGroup` for rendering specific projectile types. Update parameter naming for consistency.

