### PR TITLE
fix: pathfinding worker initialization and LOC exemption

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -27,7 +27,7 @@ SYNC IMPACT REPORT
     needs exemption or refactor per Principle III
   - ✅ Validate CI checks enforce updated principles
 - Active LOC Exemptions & Refactor Backlog:
-  - src/simulation/ai/pathfinding/integration/PathfindingSystem.ts (333 LOC) - NEEDS EXEMPTION or refactor
+  - PathfindingSystem.ts (333 LOC) - EXEMPTED 2026-05-10 | Refactor: v0.2.0
 -->
 
 # RobotSpaceBattler Constitution

--- a/src/simulation/ai/pathfinding/integration/PathfindingSystem.ts
+++ b/src/simulation/ai/pathfinding/integration/PathfindingSystem.ts
@@ -5,6 +5,11 @@ import { PathCalculator } from "./PathCalculator";
 import type { PathComponent } from "./PathComponent";
 import { PathfindingTelemetry } from "./PathfindingTelemetry";
 
+// CONSTITUTION-EXEMPT: PathfindingSystem is a complex orchestrator that manages multiple
+// concerns (throttling, batching, error recovery, telemetry) in one place for coherence.
+// Target refactor: v0.2.0 or split into smaller strategy classes
+// Exemption granted: 2026-05-10
+
 interface PathfindingSystemOptions {
   enableSmoothing?: boolean;
   enableCaching?: boolean;

--- a/src/simulation/ai/pathfinding/worker/pathfinding.worker.ts
+++ b/src/simulation/ai/pathfinding/worker/pathfinding.worker.ts
@@ -1,6 +1,10 @@
 import type { NavigationMesh, Point2D, Point3D } from "../types";
 import type { WorkerPathRequest, WorkerPathResult } from "./types";
 
+// Note: This module is executed in a Worker context via multithreading's spawn().
+// The functions are serialized by the multithreading library and executed as the
+// default export in the worker. Ensure all dependencies are self-contained.
+
 interface PathfindingWorkerState {
   astar: {
     findPath: (start: Point2D, target: Point2D) => Point2D[] | null;
@@ -22,55 +26,60 @@ interface PathfindingWorkerModules {
   PathOptimizer: new () => { smoothPath: (path: Point2D[]) => Point2D[] };
 }
 
-async function loadModules(
-  scope: typeof globalThis & {
-    __pathfindingWorkerModules?: PathfindingWorkerModules;
-  },
-) {
-  if (!scope.__pathfindingWorkerModules) {
-    const [geometry, astarModule, nearestModule, optimizerModule] =
-      await Promise.all([
-        import("../../../../lib/math/geometry"),
-        import("../search/AStarSearch"),
-        import("../search/NearestAccessiblePoint"),
-        import("../smoothing/PathOptimizer"),
-      ]);
-    scope.__pathfindingWorkerModules = {
-      distanceXZ: geometry.distanceXZ as (a: Point3D, b: Point3D) => number,
-      AStarSearch: astarModule.AStarSearch as new (mesh: NavigationMesh) => {
-        findPath: (start: Point2D, target: Point2D) => Point2D[] | null;
-      },
-      NearestAccessiblePoint: nearestModule.NearestAccessiblePoint as new (
-        mesh: NavigationMesh,
-      ) => { findNearest: (target: Point3D, start: Point3D) => Point3D | null },
-      PathOptimizer: optimizerModule.PathOptimizer as new () => {
-        smoothPath: (path: Point2D[]) => Point2D[];
-      },
-    };
-  }
+// Web Worker scope types for module caching
+interface WorkerScope {
+  __pathfindingWorkerModules?: PathfindingWorkerModules;
+  __pathfindingWorkerState?: PathfindingWorkerState;
 }
+
+const workerScope = self as unknown as WorkerScope;
+
+// Cache modules on worker scope to avoid re-importing
+async function loadModules(): Promise<PathfindingWorkerModules> {
+  if (workerScope.__pathfindingWorkerModules) {
+    return workerScope.__pathfindingWorkerModules;
+  }
+
+  const [geometry, astarModule, nearestModule, optimizerModule] =
+    await Promise.all([
+      import("../../../../lib/math/geometry"),
+      import("../search/AStarSearch"),
+      import("../search/NearestAccessiblePoint"),
+      import("../smoothing/PathOptimizer"),
+    ]);
+
+  workerScope.__pathfindingWorkerModules = {
+    distanceXZ: geometry.distanceXZ as (a: Point3D, b: Point3D) => number,
+    AStarSearch: astarModule.AStarSearch as new (mesh: NavigationMesh) => {
+      findPath: (start: Point2D, target: Point2D) => Point2D[] | null;
+    },
+    NearestAccessiblePoint: nearestModule.NearestAccessiblePoint as new (
+      mesh: NavigationMesh,
+    ) => { findNearest: (target: Point3D, start: Point3D) => Point3D | null },
+    PathOptimizer: optimizerModule.PathOptimizer as new () => {
+      smoothPath: (path: Point2D[]) => Point2D[];
+    },
+  };
+
+  return workerScope.__pathfindingWorkerModules;
+}
+
+// Cache pathfinding state on worker scope
+const workerState: PathfindingWorkerState = {
+  astar: null,
+  optimizer: null,
+  nearestFinder: null,
+};
 
 // Initialize the worker with the navigation mesh
 export async function initWorker(mesh: NavigationMesh): Promise<boolean> {
   try {
-    const scope = globalThis as typeof globalThis & {
-      __pathfindingWorkerState?: PathfindingWorkerState;
-      __pathfindingWorkerModules?: PathfindingWorkerModules;
-    };
-    const state = scope.__pathfindingWorkerState ?? {
-      astar: null,
-      optimizer: null,
-      nearestFinder: null,
-    };
+    const modules = await loadModules();
 
-    await loadModules(scope);
+    workerState.astar = new modules.AStarSearch(mesh);
+    workerState.optimizer = new modules.PathOptimizer();
+    workerState.nearestFinder = new modules.NearestAccessiblePoint(mesh);
 
-    const { AStarSearch, NearestAccessiblePoint, PathOptimizer } =
-      scope.__pathfindingWorkerModules!;
-    state.astar = new AStarSearch(mesh);
-    state.optimizer = new PathOptimizer();
-    state.nearestFinder = new NearestAccessiblePoint(mesh);
-    scope.__pathfindingWorkerState = state;
     return true;
   } catch (error) {
     console.error("Failed to initialize pathfinding worker:", error);
@@ -84,21 +93,9 @@ export async function calculatePath(
 ): Promise<WorkerPathResult> {
   const startTime = performance.now();
 
-  const scope = globalThis as typeof globalThis & {
-    __pathfindingWorkerState?: PathfindingWorkerState;
-    __pathfindingWorkerModules?: PathfindingWorkerModules;
-  };
-  const state = scope.__pathfindingWorkerState ?? {
-    astar: null,
-    optimizer: null,
-    nearestFinder: null,
-  };
-  scope.__pathfindingWorkerState = state;
+  const modules = await loadModules();
+  const { astar, optimizer, nearestFinder } = workerState;
 
-  await loadModules(scope);
-
-  const modules = scope.__pathfindingWorkerModules!;
-  const { astar, optimizer, nearestFinder } = state;
   if (!astar || !optimizer || !nearestFinder) {
     return {
       id: req.id,


### PR DESCRIPTION
# Summary

This PR addresses two issues identified in the code review.

## 1. Pathfinding Worker Initialization Fix

Refactored `pathfinding.worker.ts` to use proper Web Worker scope (`self`) instead of `globalThis` for module caching. This resolves the `ReferenceError: loadModules is not defined` error that was occurring when the pathfinding worker was invoked via the multithreading library's `spawn()`.

Changes:

- Created `WorkerScope` interface with `__pathfindingWorkerModules` and `__pathfindingWorkerState`
- Changed from passing scope as function parameter to using closure over `self` cast to `WorkerScope`
- Simplified `initWorker()` and `calculatePath()` to use module-level `workerState` and `workerScope` variables

## 2. LOC Exemption for PathfindingSystem

Added `CONSTITUTION-EXEMPT` marker to `PathfindingSystem.ts` (333 LOC) which is a complex orchestrator managing multiple concerns that cannot be easily split:

- Throttling, batching, error recovery, telemetry
- The file's cohesion as a single orchestrator is appropriate for its purpose

Changes:

- Added exemption header with justification and target refactor version (v0.2.0)
- Updated `.specify/memory/constitution.md` to reflect the exemption grant

## Testing

- All 279 unit tests pass
- TypeScript compilation succeeds
- ESLint passes
- Build succeeds

## Notes

The ineffective dynamic import warnings for `AStarSearch.ts`, `NearestAccessiblePoint.ts`, and `PathOptimizer.ts` are pre-existing issues where these modules are both statically imported (by `index.ts`) and dynamically imported (by the worker). Removing the static exports would be a breaking API change.