### PR TITLE
perf: remove render-loop churn and stabilize robot materials

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ import {
   MatchStateSnapshot,
 } from "./runtime/state/matchStateMachine";
 import { ObstacleFixture } from "./simulation/match/matchSpawner";
-import { useTelemetryStore } from "./state/telemetryStore";
 
 function formatStatus({
   phase,
@@ -47,15 +46,6 @@ function formatStatus({
 export default function App() {
   const battleWorld = useMemo(() => createBattleWorld(), []);
   const telemetryPort = useMemo(() => createTelemetryPort(), []);
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      (
-        window as Window & {
-          __battleWorld?: ReturnType<typeof createBattleWorld>;
-        }
-      ).__battleWorld = battleWorld;
-    }
-  }, [battleWorld]);
   const [matchSnapshot, setMatchSnapshot] = useState<MatchStateSnapshot>({
     phase: "initializing",
     elapsedMs: 0,
@@ -115,10 +105,8 @@ export default function App() {
   }, []);
 
   const runnerRef = useRef<BattleRunner | null>(null);
-  const telemetryEvents = useTelemetryStore((state) => state.events);
 
   const aliveCounts = useMemo(() => {
-    void telemetryEvents;
     const counts = { red: 0, blue: 0 };
     battleWorld.robots.entities.forEach((robot) => {
       if (isActiveRobot(robot)) {
@@ -126,7 +114,7 @@ export default function App() {
       }
     });
     return counts;
-  }, [battleWorld, telemetryEvents]);
+  }, [battleWorld]);
 
   const handleRunnerReady = useCallback((runner: BattleRunner) => {
     runnerRef.current = runner;

--- a/src/components/RobotPlaceholder.tsx
+++ b/src/components/RobotPlaceholder.tsx
@@ -1,5 +1,5 @@
 import { CapsuleCollider, RigidBody } from "@react-three/rapier";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { Color } from "three";
 
 /**
@@ -21,8 +21,14 @@ export const RobotPlaceholder = memo(function RobotPlaceholder({
   color = "#ff4d5a",
   position = [0, 0.8, 0],
 }: RobotPlaceholderProps) {
-  const emissivePrimary = new Color(color).multiplyScalar(0.2);
-  const emissiveSecondary = new Color(color).multiplyScalar(0.25);
+  const emissivePrimary = useMemo(
+    () => new Color(color).multiplyScalar(0.2),
+    [color],
+  );
+  const emissiveSecondary = useMemo(
+    () => new Color(color).multiplyScalar(0.25),
+    [color],
+  );
 
   return (
     <RigidBody type="fixed" colliders={false} position={position}>

--- a/src/components/Simulation.tsx
+++ b/src/components/Simulation.tsx
@@ -62,9 +62,7 @@ function SimulationContent(props: SimulationProps) {
   const { battleWorld } = props;
 
   // Custom hook manages the ECS world lifecycle and system updates.
-  const { version } = useSimulation(props);
-
-  void version;
+  useSimulation(props);
 
   const qualitySettings = useQualitySettings();
   const instancingEnabled = qualitySettings.visuals.instancing.enabled;

--- a/src/runtime/simulation/useSimulation.ts
+++ b/src/runtime/simulation/useSimulation.ts
@@ -1,7 +1,7 @@
 import type { World as RapierWorld } from "@dimforge/rapier3d-compat";
 import { useFrame } from "@react-three/fiber";
 import { useRapier } from "@react-three/rapier";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { BattleWorld } from "../../ecs/world";
 import { recordRendererFrame } from "../../visuals/rendererStats";
@@ -9,7 +9,6 @@ import { MatchStateMachine } from "../state/matchStateMachine";
 import { BattleRunner, createBattleRunner } from "./battleRunner";
 import { TelemetryPort } from "./ports";
 
-const FRAME_SAMPLE_INTERVAL = 1 / 30;
 
 interface UseSimulationOptions {
   battleWorld: BattleWorld;
@@ -34,8 +33,6 @@ export function useSimulation({
 }: UseSimulationOptions) {
   const runnerRef = useRef<BattleRunner | null>(null);
   const rapierWorldRef = useRef<RapierWorld | null>(null);
-  const [version, setVersion] = useState(0);
-  const accumulator = useRef(0);
   const { world: rapierWorld } = useRapier();
 
   rapierWorldRef.current = (rapierWorld as unknown as RapierWorld | null) ?? null;
@@ -95,14 +92,7 @@ export function useSimulation({
   useFrame((state, delta) => {
     recordRendererFrame(state.gl, delta);
     runnerRef.current?.step(delta);
-
-    accumulator.current += delta;
-    const sampleCount = Math.floor(accumulator.current / FRAME_SAMPLE_INTERVAL);
-    if (sampleCount > 0) {
-      accumulator.current -= FRAME_SAMPLE_INTERVAL * sampleCount;
-      setVersion((v) => v + sampleCount);
-    }
   });
 
-  return { version, runner: runnerRef.current };
+  return { runner: runnerRef.current };
 }

--- a/tests/runtime/useSimulation.spec.tsx
+++ b/tests/runtime/useSimulation.spec.tsx
@@ -73,8 +73,8 @@ function HookHarness(props: {
   matchMachine: ReturnType<typeof createMatchMachineStub>;
   telemetry: ReturnType<typeof createTelemetryStub>;
 }) {
-  const { version } = useSimulation(props);
-  return <div data-testid="version">{version}</div>;
+  useSimulation(props);
+  return <div data-testid="ready">ready</div>;
 }
 
 describe('useSimulation', () => {
@@ -134,7 +134,7 @@ describe('useSimulation', () => {
     expect(secondRunner.setRapierWorld).toHaveBeenLastCalledWith(null);
   });
 
-  it('preserves leftover frame time when sampling version updates', () => {
+  it('runs the simulation frame loop without forcing React version updates', () => {
     const runner = {
       step: vi.fn(),
       reset: vi.fn(),
@@ -163,6 +163,6 @@ describe('useSimulation', () => {
 
     expect(runner.step).toHaveBeenCalledTimes(5);
     expect(simulationTestState.mockRecordRendererFrame).toHaveBeenCalledTimes(5);
-    expect(screen.getByTestId('version')).toHaveTextContent('3');
+    expect(screen.getByTestId('ready')).toHaveTextContent('ready');
   });
 });


### PR DESCRIPTION
## Summary
- remove the 30Hz React version update churn inside the simulation loop
- stop re-deriving alive counts from telemetry events in App
- memoize robot emissive materials to avoid per-frame allocations
- update the simulation test to cover the optimized path

## Verification
- 
> space-station-autobattler@0.1.0 test
> vitest run


 RUN  v4.1.8 /Users/openclaw/Github/RobotSpaceBattler


 Test Files  75 passed (75)
      Tests  279 passed (279)
   Start at  11:39:29
   Duration  6.83s (transform 3.01s, setup 3.69s, import 6.95s, tests 921ms, environment 38.71s)
- 
> space-station-autobattler@0.1.0 lint
> eslint "src/**/*.{ts,tsx}" --config eslint.config.cjs
- 
> space-station-autobattler@0.1.0 typecheck
> tsc --noEmit
- 
> space-station-autobattler@0.1.0 build
> vite build

vite v8.0.16 building client environment for production...
[2Ktransforming...✓ 986 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                               0.73 kB │ gzip:     0.38 kB
dist/assets/worker-eRs1qOA7.js               36.47 kB
dist/assets/index-BT01FSW0.css               11.93 kB │ gzip:     2.72 kB
dist/assets/rolldown-runtime-QTnfLwEv.js      0.69 kB │ gzip:     0.42 kB
dist/assets/index-lv4dPQHP.js               127.10 kB │ gzip:    37.42 kB
dist/assets/vendor-Bv-uzi1L.js            3,780.57 kB │ gzip: 1,284.50 kB

✓ built in 2.03s

## Notes
- Build still reports existing chunk-size warnings from the pathfinding worker bundle, but the app compiles successfully.