### PR TITLE
[codex] Fix GitHub Pages deploy by running on Node 22

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary

Fixes the failing GitHub Pages deployment ([run 30661490318](https://github.com/deadronos/RobotSpaceBattler/actions/runs/30661490318)) caused by the dependency upgrade: the deploy workflow still ran tests on Node 20, but the newly upgraded `jsdom@30` / `undici@8` require Node 22.22.2+.

## Root cause

The upgraded `jsdom@30` declares `engines: { node: "^22.22.2 || ^24.15.0 || >=26.0.0" }` and depends on `undici@8.9.0` (`engines: >=22.19.0`). undici 8 calls `worker_threads.markAsUncloneable`, which does not exist on Node 20, so every vitest worker crashed while loading jsdom:

```
TypeError: webidl.util.markAsUncloneable is not a function
  at new CacheStorage node_modules/undici/lib/web/cache/cachestorage.js:20:17
  at Object.<anonymous> node_modules/undici/index.js:179:25
```

## Fix

- Bumped the deploy workflow to `actions/setup-node` with `node-version: '22'` (satisfies jsdom's `^22.22.2` requirement).
- Added an `engines` field to `package.json` documenting the required Node range so future installs fail loudly instead of emitting silent EBADENGINE warnings.

## Validation

- Full test suite under Node 22.23.2: 75 files, 279 tests, all pass (previously crashed on Node 20).
- `tsc --noEmit` under Node 22.23.2: pass.
- Production build under Node 22.23.2: pass.
- No source code changed; only CI config and package metadata.

## CONSTITUTION-CHECK

- File-size: no source files changed; the two config/metadata files remain far under 300 LOC.
- Tests: TDD not applicable (CI/config-only change); full suite (279 tests) passes.
- r3f: render vs simulation separation maintained; no source code touched.
